### PR TITLE
Refactor settings layout and extend ticket email templates

### DIFF
--- a/app/Notifications/TicketSaleNotification.php
+++ b/app/Notifications/TicketSaleNotification.php
@@ -4,10 +4,12 @@ namespace App\Notifications;
 
 use App\Models\Role;
 use App\Models\Sale;
+use App\Support\MailTemplateManager;
+use App\Utils\NotificationUtils;
+use App\Utils\UrlUtils;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
-use App\Utils\NotificationUtils;
 
 class TicketSaleNotification extends Notification
 {
@@ -38,26 +40,43 @@ class TicketSaleNotification extends Notification
         $amount = $this->sale->payment_amount ?? $this->sale->calculateTotal();
         $currency = $event->ticket_currency_code ?? 'USD';
         $formattedAmount = number_format((float) $amount, 2) . ' ' . $currency;
+        $ticketViewUrl = route('ticket.view', [
+            'event_id' => UrlUtils::encodeId($event->id),
+            'secret' => $this->sale->secret,
+        ]);
 
-        $mail = (new MailMessage)
-            ->subject(__('messages.ticket_sale_subject', ['event' => $eventName]));
+        $templates = app(MailTemplateManager::class);
+        $templateKey = $this->recipientType === 'purchaser'
+            ? 'ticket_sale_purchaser'
+            : 'ticket_sale_organizer';
 
-        if ($this->recipientType === 'purchaser') {
-            $mail->line(__('messages.ticket_sale_line_purchaser', [
-                'quantity' => $quantity,
-                'event' => $eventName,
-                'date' => $date ?: __('messages.date_to_be_announced'),
-            ]));
-        } else {
-            $mail->line(__('messages.ticket_sale_line_organizer', [
-                'buyer' => $this->sale->name ?: $this->sale->email,
-                'quantity' => $quantity,
-                'event' => $eventName,
-                'amount' => $formattedAmount,
-            ]));
-        }
+        $eventDate = $date ?: __('messages.date_to_be_announced');
+        $buyerName = $this->sale->name ?: $this->sale->email;
+        $buyerEmail = $this->sale->email ?? '';
 
-        $mail->action(__('messages.view_event'), $event->getGuestUrl($this->sale->subdomain, $this->sale->event_date));
+        $data = [
+            'event_name' => $eventName,
+            'event_date' => $eventDate,
+            'ticket_quantity' => $quantity,
+            'amount_total' => $formattedAmount,
+            'buyer_name' => $buyerName,
+            'buyer_email' => $buyerEmail,
+            'event_url' => $event->getGuestUrl($this->sale->subdomain, $this->sale->event_date),
+            'ticket_view_url' => $this->recipientType === 'purchaser'
+                ? $ticketViewUrl
+                : $event->getGuestUrl($this->sale->subdomain, $this->sale->event_date),
+            'order_reference' => (string) $this->sale->id,
+            'app_name' => config('app.name'),
+        ];
+
+        $subject = $templates->renderSubject($templateKey, $data);
+        $body = $templates->renderBody($templateKey, $data);
+
+        $mail = (new MailMessage())
+            ->subject($subject)
+            ->markdown('mail.templates.generic', [
+                'body' => $body,
+            ]);
 
         if ($event->user && $event->user->email) {
             $mail->replyTo($event->user->email, $event->user->name);

--- a/config/mail_templates.php
+++ b/config/mail_templates.php
@@ -70,5 +70,132 @@ MD,
                 ':app_name' => 'The application name configured in settings.',
             ],
         ],
+        'ticket_sale_purchaser' => [
+            'label' => 'Ticket reservation confirmation (purchaser)',
+            'description' => 'Sent to attendees after they reserve tickets for an event.',
+            'subject' => 'Your ticket reservation for :event_name',
+            'body' => <<<'MD'
+# Hello!
+
+:subject_line
+
+- **Event:** :event_name
+- **Date:** :event_date
+- **Tickets:** :ticket_quantity
+
+[View Event](:event_url)
+
+[View Your Tickets](:ticket_view_url)
+
+Thanks,
+:app_name
+MD,
+            'placeholders' => [
+                ':subject_line' => 'The email subject line with placeholders applied.',
+                ':event_name' => 'Name of the event.',
+                ':event_date' => 'Date of the event, or "Date to be announced" when not available.',
+                ':ticket_quantity' => 'Number of tickets reserved in the order.',
+                ':event_url' => 'Public link where the recipient can view the event.',
+                ':ticket_view_url' => 'Private link where the purchaser can view their order and tickets.',
+                ':buyer_name' => 'Name provided by the purchaser.',
+                ':buyer_email' => 'Email address provided by the purchaser.',
+                ':order_reference' => 'Internal reference number for the order.',
+                ':app_name' => 'The application name configured in settings.',
+            ],
+        ],
+        'ticket_sale_organizer' => [
+            'label' => 'Ticket reservation notification (organizer)',
+            'description' => 'Sent to organizers when a new ticket reservation is created.',
+            'subject' => 'New ticket reservation for :event_name',
+            'body' => <<<'MD'
+# Hello!
+
+:subject_line
+
+- **Buyer:** :buyer_name (:buyer_email)
+- **Tickets:** :ticket_quantity
+- **Date:** :event_date
+- **Total:** :amount_total
+- **Order #:** :order_reference
+
+[View Event](:event_url)
+
+Thanks,
+:app_name
+MD,
+            'placeholders' => [
+                ':subject_line' => 'The email subject line with placeholders applied.',
+                ':event_name' => 'Name of the event.',
+                ':event_date' => 'Date of the event, or "Date to be announced" when not available.',
+                ':ticket_quantity' => 'Number of tickets reserved in the order.',
+                ':amount_total' => 'Total amount reserved or paid, including the currency.',
+                ':buyer_name' => 'Name provided by the purchaser.',
+                ':buyer_email' => 'Email address provided by the purchaser.',
+                ':event_url' => 'Public link where the recipient can view the event.',
+                ':order_reference' => 'Internal reference number for the order.',
+                ':app_name' => 'The application name configured in settings.',
+            ],
+        ],
+        'ticket_paid_purchaser' => [
+            'label' => 'Ticket payment confirmation (purchaser)',
+            'description' => 'Sent to attendees after their order is marked as paid.',
+            'subject' => 'Payment received for :event_name',
+            'body' => <<<'MD'
+# Hello!
+
+:subject_line
+
+- **Event:** :event_name
+- **Date:** :event_date
+- **Amount Paid:** :amount_total
+- **Order #:** :order_reference
+
+[View Your Tickets](:ticket_view_url)
+
+Thanks,
+:app_name
+MD,
+            'placeholders' => [
+                ':subject_line' => 'The email subject line with placeholders applied.',
+                ':event_name' => 'Name of the event.',
+                ':event_date' => 'Date of the event, or "Date to be announced" when not available.',
+                ':amount_total' => 'Total amount paid, including the currency.',
+                ':ticket_view_url' => 'Private link where the purchaser can view their order and tickets.',
+                ':order_reference' => 'Internal reference number for the order.',
+                ':app_name' => 'The application name configured in settings.',
+            ],
+        ],
+        'ticket_paid_organizer' => [
+            'label' => 'Ticket payment notification (organizer)',
+            'description' => 'Sent to organizers when an order is marked as paid.',
+            'subject' => 'Ticket payment received for :event_name',
+            'body' => <<<'MD'
+# Hello!
+
+:subject_line
+
+- **Buyer:** :buyer_name (:buyer_email)
+- **Event:** :event_name
+- **Date:** :event_date
+- **Amount Paid:** :amount_total
+- **Order #:** :order_reference
+
+[View Event](:event_url)
+
+Thanks,
+:app_name
+MD,
+            'placeholders' => [
+                ':subject_line' => 'The email subject line with placeholders applied.',
+                ':event_name' => 'Name of the event.',
+                ':event_date' => 'Date of the event, or "Date to be announced" when not available.',
+                ':amount_total' => 'Total amount paid, including the currency.',
+                ':buyer_name' => 'Name provided by the purchaser.',
+                ':buyer_email' => 'Email address provided by the purchaser.',
+                ':event_url' => 'Public link where the recipient can view the event.',
+                ':order_reference' => 'Internal reference number for the order.',
+                ':app_name' => 'The application name configured in settings.',
+            ],
+        ],
     ],
 ];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -91,6 +91,8 @@ return [
     'colors' => 'Colors',
     'rotation' => 'Rotation',
     'settings' => 'Settings',
+    'settings_overview_description' => 'Choose a settings category to update application preferences.',
+    'back_to_settings' => 'Back to settings overview',
     'application_information' => 'Application Information',
     'application_information_description' => 'Review deployment details including the current build number.',
     'build_number' => 'Build Number',

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -139,7 +139,7 @@
         @if (auth()->user()->isAdmin())
         <li class="mt-auto">
             <a href="{{ route('settings.index') }}"
-                class="group -mx-2 flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->is('settings') ? 'bg-gray-800 text-white' : '' }}">
+                class="group -mx-2 flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->is('settings*') ? 'bg-gray-800 text-white' : '' }}">
                 <svg class="h-6 w-6 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
                     stroke="currentColor" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round"

--- a/resources/views/settings/email-templates.blade.php
+++ b/resources/views/settings/email-templates.blade.php
@@ -1,0 +1,108 @@
+<x-app-admin-layout>
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto space-y-6">
+            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
+                <div class="max-w-3xl">
+                    <div class="mb-6">
+                        <a href="{{ route('settings.index') }}" class="inline-flex items-center gap-2 text-sm font-medium text-[#4E81FA] hover:text-[#365fcc]">
+                            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+                            </svg>
+                            {{ __('messages.back_to_settings') }}
+                        </a>
+                    </div>
+
+                    <section>
+                        <header>
+                            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+                                {{ __('messages.email_templates') }}
+                            </h2>
+
+                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                {{ __('messages.email_templates_description') }}
+                            </p>
+                        </header>
+
+                        <form method="post" action="{{ route('settings.mail_templates.update') }}" class="mt-6 space-y-6">
+                            @csrf
+                            @method('patch')
+
+                            @foreach($mailTemplates as $template)
+                                <div class="p-4 sm:p-6 border border-gray-200 dark:border-gray-700 rounded-lg space-y-6">
+                                    <div>
+                                        <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">
+                                            {{ $template['label'] }}
+                                        </h3>
+
+                                        @if(!empty($template['description']))
+                                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                                {{ $template['description'] }}
+                                            </p>
+                                        @endif
+                                    </div>
+
+                                    <div class="space-y-6">
+                                        @if(isset($template['subject']))
+                                            <div>
+                                                <x-input-label for="mail_templates_{{ $template['key'] }}_subject" :value="__('messages.email_template_subject')" />
+                                                <x-text-input id="mail_templates_{{ $template['key'] }}_subject" name="mail_templates[{{ $template['key'] }}][subject]" type="text" class="mt-1 block w-full" :value="old('mail_templates.' . $template['key'] . '.subject', $template['subject'])" />
+                                                <x-input-error class="mt-2" :messages="$errors->get('mail_templates.' . $template['key'] . '.subject')" />
+                                            </div>
+                                        @endif
+
+                                        @if(!empty($template['has_subject_curated']) && isset($template['subject_curated']))
+                                            <div>
+                                                <x-input-label for="mail_templates_{{ $template['key'] }}_subject_curated" :value="__('messages.email_template_subject_curated')" />
+                                                <x-text-input id="mail_templates_{{ $template['key'] }}_subject_curated" name="mail_templates[{{ $template['key'] }}][subject_curated]" type="text" class="mt-1 block w-full" :value="old('mail_templates.' . $template['key'] . '.subject_curated', $template['subject_curated'])" />
+                                                <x-input-error class="mt-2" :messages="$errors->get('mail_templates.' . $template['key'] . '.subject_curated')" />
+                                            </div>
+                                        @endif
+
+                                        @if(isset($template['body']))
+                                            <div>
+                                                <x-input-label for="mail_templates_{{ $template['key'] }}_body" :value="__('messages.email_template_body')" />
+                                                <textarea id="mail_templates_{{ $template['key'] }}_body" name="mail_templates[{{ $template['key'] }}][body]" rows="8"
+                                                    class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-[#4E81FA] dark:focus:border-[#4E81FA] focus:ring-[#4E81FA] dark:focus:ring-[#4E81FA] rounded-md shadow-sm">{{ old('mail_templates.' . $template['key'] . '.body', $template['body']) }}</textarea>
+                                                <x-input-error class="mt-2" :messages="$errors->get('mail_templates.' . $template['key'] . '.body')" />
+                                                <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                                                    {{ __('messages.email_template_markdown_hint') }}
+                                                </p>
+                                            </div>
+                                        @endif
+
+                                        @if(!empty($template['placeholders']))
+                                            <div class="text-sm text-gray-600 dark:text-gray-400">
+                                                <p class="font-medium">
+                                                    {{ __('messages.email_template_placeholders') }}
+                                                </p>
+                                                <ul class="mt-2 space-y-1 text-xs sm:text-sm">
+                                                    @foreach($template['placeholders'] as $placeholder => $description)
+                                                        <li>
+                                                            <code class="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-900 dark:text-gray-100 rounded">
+                                                                {{ $placeholder }}
+                                                            </code>
+                                                            <span class="ml-2">{{ $description }}</span>
+                                                        </li>
+                                                    @endforeach
+                                                </ul>
+                                            </div>
+                                        @endif
+                                    </div>
+                                </div>
+                            @endforeach
+
+                            <div class="flex items-center gap-4">
+                                <x-primary-button>{{ __('messages.save') }}</x-primary-button>
+
+                                @if (session('status') === 'mail-templates-updated')
+                                    <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)"
+                                        class="text-sm text-gray-600 dark:text-gray-400">{{ __('messages.email_templates_saved') }}</p>
+                                @endif
+                            </div>
+                        </form>
+                    </section>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-admin-layout>

--- a/resources/views/settings/email.blade.php
+++ b/resources/views/settings/email.blade.php
@@ -1,0 +1,118 @@
+<x-app-admin-layout>
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto space-y-6">
+            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
+                <div class="max-w-3xl">
+                    <div class="mb-6">
+                        <a href="{{ route('settings.index') }}" class="inline-flex items-center gap-2 text-sm font-medium text-[#4E81FA] hover:text-[#365fcc]">
+                            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+                            </svg>
+                            {{ __('messages.back_to_settings') }}
+                        </a>
+                    </div>
+
+                    <section>
+                        <header>
+                            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+                                {{ __('messages.email_settings') }}
+                            </h2>
+
+                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                {{ __('messages.email_settings_description') }}
+                            </p>
+                        </header>
+
+                        <form method="post" action="{{ route('settings.mail.update') }}" class="mt-6 space-y-6">
+                            @csrf
+                            @method('patch')
+
+                            <div>
+                                <x-input-label for="mail_mailer" :value="__('messages.mail_mailer')" />
+                                <select id="mail_mailer" name="mail_mailer"
+                                    class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-[#4E81FA] dark:focus:border-[#4E81FA] focus:ring-[#4E81FA] dark:focus:ring-[#4E81FA] rounded-md shadow-sm">
+                                    @foreach($availableMailers as $value => $label)
+                                        <option value="{{ $value }}" {{ old('mail_mailer', $mailSettings['mailer']) === $value ? 'selected' : '' }}>
+                                            {{ $label }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                                <x-input-error class="mt-2" :messages="$errors->get('mail_mailer')" />
+                            </div>
+
+                            <div class="grid gap-6 sm:grid-cols-2">
+                                <div>
+                                    <x-input-label for="mail_host" :value="__('messages.mail_host')" />
+                                    <x-text-input id="mail_host" name="mail_host" type="text" class="mt-1 block w-full"
+                                        :value="old('mail_host', $mailSettings['host'])" autocomplete="off" />
+                                    <x-input-error class="mt-2" :messages="$errors->get('mail_host')" />
+                                </div>
+
+                                <div>
+                                    <x-input-label for="mail_port" :value="__('messages.mail_port')" />
+                                    <x-text-input id="mail_port" name="mail_port" type="number" class="mt-1 block w-full"
+                                        :value="old('mail_port', $mailSettings['port'])" min="1" max="65535" />
+                                    <x-input-error class="mt-2" :messages="$errors->get('mail_port')" />
+                                </div>
+                            </div>
+
+                            <div class="grid gap-6 sm:grid-cols-2">
+                                <div>
+                                    <x-input-label for="mail_username" :value="__('messages.mail_username')" />
+                                    <x-text-input id="mail_username" name="mail_username" type="text" class="mt-1 block w-full"
+                                        :value="old('mail_username', $mailSettings['username'])" autocomplete="off" />
+                                    <x-input-error class="mt-2" :messages="$errors->get('mail_username')" />
+                                </div>
+
+                                <div>
+                                    <x-input-label for="mail_password" :value="__('messages.mail_password')" />
+                                    <x-text-input id="mail_password" name="mail_password" type="password" class="mt-1 block w-full"
+                                        :value="old('mail_password')" autocomplete="new-password" />
+                                    <x-input-error class="mt-2" :messages="$errors->get('mail_password')" />
+                                </div>
+                            </div>
+
+                            <div class="grid gap-6 sm:grid-cols-2">
+                                <div>
+                                    <x-input-label for="mail_encryption" :value="__('messages.mail_encryption')" />
+                                    <select id="mail_encryption" name="mail_encryption"
+                                        class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-[#4E81FA] dark:focus:border-[#4E81FA] focus:ring-[#4E81FA] dark:focus:ring-[#4E81FA] rounded-md shadow-sm">
+                                        @foreach($availableEncryptions as $value => $label)
+                                            <option value="{{ $value }}" {{ old('mail_encryption', $mailSettings['encryption'] ?? '') === $value ? 'selected' : '' }}>
+                                                {{ $label }}
+                                            </option>
+                                        @endforeach
+                                    </select>
+                                    <x-input-error class="mt-2" :messages="$errors->get('mail_encryption')" />
+                                </div>
+
+                                <div>
+                                    <x-input-label for="mail_from_name" :value="__('messages.mail_from_name')" />
+                                    <x-text-input id="mail_from_name" name="mail_from_name" type="text" class="mt-1 block w-full"
+                                        :value="old('mail_from_name', $mailSettings['from_name'])" />
+                                    <x-input-error class="mt-2" :messages="$errors->get('mail_from_name')" />
+                                </div>
+                            </div>
+
+                            <div>
+                                <x-input-label for="mail_from_address" :value="__('messages.mail_from_address')" />
+                                <x-text-input id="mail_from_address" name="mail_from_address" type="email" class="mt-1 block w-full"
+                                    :value="old('mail_from_address', $mailSettings['from_address'])" autocomplete="off" />
+                                <x-input-error class="mt-2" :messages="$errors->get('mail_from_address')" />
+                            </div>
+
+                            <div class="flex items-center gap-4">
+                                <x-primary-button>{{ __('messages.save') }}</x-primary-button>
+
+                                @if (session('status') === 'mail-settings-updated')
+                                    <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)"
+                                        class="text-sm text-gray-600 dark:text-gray-400">{{ __('messages.email_settings_saved') }}</p>
+                                @endif
+                            </div>
+                        </form>
+                    </section>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-admin-layout>

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -6,223 +6,58 @@
                     <section>
                         <header>
                             <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
-                                {{ __('messages.email_settings') }}
+                                {{ __('messages.settings') }}
                             </h2>
 
                             <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                                {{ __('messages.email_settings_description') }}
+                                {{ __('messages.settings_overview_description') }}
                             </p>
                         </header>
 
-                        <form method="post" action="{{ route('settings.mail.update') }}" class="mt-6 space-y-6">
-                            @csrf
-                            @method('patch')
-
-                            <div>
-                                <x-input-label for="mail_mailer" :value="__('messages.mail_mailer')" />
-                                <select id="mail_mailer" name="mail_mailer"
-                                    class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-[#4E81FA] dark:focus:border-[#4E81FA] focus:ring-[#4E81FA] dark:focus:ring-[#4E81FA] rounded-md shadow-sm">
-                                    @foreach($availableMailers as $value => $label)
-                                        <option value="{{ $value }}" {{ old('mail_mailer', $mailSettings['mailer']) === $value ? 'selected' : '' }}>
-                                            {{ $label }}
-                                        </option>
-                                    @endforeach
-                                </select>
-                                <x-input-error class="mt-2" :messages="$errors->get('mail_mailer')" />
-                            </div>
-
-                            <div class="grid gap-6 sm:grid-cols-2">
-                                <div>
-                                    <x-input-label for="mail_host" :value="__('messages.mail_host')" />
-                                    <x-text-input id="mail_host" name="mail_host" type="text" class="mt-1 block w-full"
-                                        :value="old('mail_host', $mailSettings['host'])" autocomplete="off" />
-                                    <x-input-error class="mt-2" :messages="$errors->get('mail_host')" />
-                                </div>
-
-                                <div>
-                                    <x-input-label for="mail_port" :value="__('messages.mail_port')" />
-                                    <x-text-input id="mail_port" name="mail_port" type="number" class="mt-1 block w-full"
-                                        :value="old('mail_port', $mailSettings['port'])" min="1" max="65535" />
-                                    <x-input-error class="mt-2" :messages="$errors->get('mail_port')" />
-                                </div>
-                            </div>
-
-                            <div class="grid gap-6 sm:grid-cols-2">
-                                <div>
-                                    <x-input-label for="mail_username" :value="__('messages.mail_username')" />
-                                    <x-text-input id="mail_username" name="mail_username" type="text" class="mt-1 block w-full"
-                                        :value="old('mail_username', $mailSettings['username'])" autocomplete="off" />
-                                    <x-input-error class="mt-2" :messages="$errors->get('mail_username')" />
-                                </div>
-
-                                <div>
-                                    <x-input-label for="mail_password" :value="__('messages.mail_password')" />
-                                    <x-text-input id="mail_password" name="mail_password" type="password" class="mt-1 block w-full"
-                                        :value="old('mail_password')" autocomplete="new-password" />
-                                    <x-input-error class="mt-2" :messages="$errors->get('mail_password')" />
-                                </div>
-                            </div>
-
-                            <div class="grid gap-6 sm:grid-cols-2">
-                                <div>
-                                    <x-input-label for="mail_encryption" :value="__('messages.mail_encryption')" />
-                                    <select id="mail_encryption" name="mail_encryption"
-                                        class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-[#4E81FA] dark:focus:border-[#4E81FA] focus:ring-[#4E81FA] dark:focus:ring-[#4E81FA] rounded-md shadow-sm">
-                                        @foreach($availableEncryptions as $value => $label)
-                                            <option value="{{ $value }}" {{ old('mail_encryption', $mailSettings['encryption'] ?? '') === $value ? 'selected' : '' }}>
-                                                {{ $label }}
-                                            </option>
-                                        @endforeach
-                                    </select>
-                                    <x-input-error class="mt-2" :messages="$errors->get('mail_encryption')" />
-                                </div>
-
-                                <div>
-                                    <x-input-label for="mail_from_name" :value="__('messages.mail_from_name')" />
-                                    <x-text-input id="mail_from_name" name="mail_from_name" type="text" class="mt-1 block w-full"
-                                        :value="old('mail_from_name', $mailSettings['from_name'])" />
-                                    <x-input-error class="mt-2" :messages="$errors->get('mail_from_name')" />
-                                </div>
-                            </div>
-
-                            <div>
-                                <x-input-label for="mail_from_address" :value="__('messages.mail_from_address')" />
-                                <x-text-input id="mail_from_address" name="mail_from_address" type="email" class="mt-1 block w-full"
-                                    :value="old('mail_from_address', $mailSettings['from_address'])" autocomplete="off" />
-                                <x-input-error class="mt-2" :messages="$errors->get('mail_from_address')" />
-                            </div>
-
-                            <div class="flex items-center gap-4">
-                                <x-primary-button>{{ __('messages.save') }}</x-primary-button>
-
-                                @if (session('status') === 'mail-settings-updated')
-                                    <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)"
-                                        class="text-sm text-gray-600 dark:text-gray-400">{{ __('messages.email_settings_saved') }}</p>
-                                @endif
-                            </div>
-                        </form>
-                    </section>
-                </div>
-            </div>
-
-            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
-                <div class="max-w-3xl">
-                    <section>
-                        <header>
-                            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
-                                {{ __('messages.email_templates') }}
-                            </h2>
-
-                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                                {{ __('messages.email_templates_description') }}
-                            </p>
-                        </header>
-
-                        <form method="post" action="{{ route('settings.mail_templates.update') }}" class="mt-6 space-y-6">
-                            @csrf
-                            @method('patch')
-
-                            @foreach($mailTemplates as $template)
-                                <div class="p-4 sm:p-6 border border-gray-200 dark:border-gray-700 rounded-lg space-y-6">
+                        <div class="mt-6 grid gap-6 sm:grid-cols-2">
+                            <a href="{{ route('settings.email') }}"
+                               class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
+                                <div class="flex items-start justify-between gap-3">
                                     <div>
-                                        <h3 class="text-base font-semibold text-gray-900 dark:text-gray-100">
-                                            {{ $template['label'] }}
+                                        <h3 class="text-base font-semibold text-gray-900 transition group-hover:text-[#4E81FA] dark:text-gray-100">
+                                            {{ __('messages.email_settings') }}
                                         </h3>
-
-                                        @if(!empty($template['description']))
-                                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                                                {{ $template['description'] }}
-                                            </p>
-                                        @endif
+                                        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                            {{ __('messages.email_settings_description') }}
+                                        </p>
                                     </div>
+                                    <span class="text-gray-300 transition group-hover:text-[#4E81FA] dark:text-gray-600">
+                                        <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                                        </svg>
+                                    </span>
+                                </div>
+                                <span class="mt-auto text-sm font-medium text-[#4E81FA]">
+                                    {{ __('messages.view_details') }}
+                                </span>
+                            </a>
 
-                                    <div class="space-y-6">
-                                        @if(isset($template['subject']))
-                                            <div>
-                                                <x-input-label for="mail_templates_{{ $template['key'] }}_subject" :value="__('messages.email_template_subject')" />
-                                                <x-text-input id="mail_templates_{{ $template['key'] }}_subject" name="mail_templates[{{ $template['key'] }}][subject]" type="text" class="mt-1 block w-full" :value="old('mail_templates.' . $template['key'] . '.subject', $template['subject'])" />
-                                                <x-input-error class="mt-2" :messages="$errors->get('mail_templates.' . $template['key'] . '.subject')" />
-                                            </div>
-                                        @endif
-
-                                        @if(!empty($template['has_subject_curated']) && isset($template['subject_curated']))
-                                            <div>
-                                                <x-input-label for="mail_templates_{{ $template['key'] }}_subject_curated" :value="__('messages.email_template_subject_curated')" />
-                                                <x-text-input id="mail_templates_{{ $template['key'] }}_subject_curated" name="mail_templates[{{ $template['key'] }}][subject_curated]" type="text" class="mt-1 block w-full" :value="old('mail_templates.' . $template['key'] . '.subject_curated', $template['subject_curated'])" />
-                                                <x-input-error class="mt-2" :messages="$errors->get('mail_templates.' . $template['key'] . '.subject_curated')" />
-                                            </div>
-                                        @endif
-
-                                        @if(isset($template['body']))
-                                            <div>
-                                                <x-input-label for="mail_templates_{{ $template['key'] }}_body" :value="__('messages.email_template_body')" />
-                                                <textarea id="mail_templates_{{ $template['key'] }}_body" name="mail_templates[{{ $template['key'] }}][body]" rows="8"
-                                                    class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-[#4E81FA] dark:focus:border-[#4E81FA] focus:ring-[#4E81FA] dark:focus:ring-[#4E81FA] rounded-md shadow-sm">{{ old('mail_templates.' . $template['key'] . '.body', $template['body']) }}</textarea>
-                                                <x-input-error class="mt-2" :messages="$errors->get('mail_templates.' . $template['key'] . '.body')" />
-                                                <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
-                                                    {{ __('messages.email_template_markdown_hint') }}
-                                                </p>
-                                            </div>
-                                        @endif
-
-                                        @if(!empty($template['placeholders']))
-                                            <div class="text-sm text-gray-600 dark:text-gray-400">
-                                                <p class="font-medium">
-                                                    {{ __('messages.email_template_placeholders') }}
-                                                </p>
-                                                <ul class="mt-2 space-y-1 text-xs sm:text-sm">
-                                                    @foreach($template['placeholders'] as $placeholder => $description)
-                                                        <li>
-                                                            <code class="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-900 dark:text-gray-100 rounded">
-                                                                {{ $placeholder }}
-                                                            </code>
-                                                            <span class="ml-2">{{ $description }}</span>
-                                                        </li>
-                                                    @endforeach
-                                                </ul>
-                                            </div>
-                                        @endif
+                            <a href="{{ route('settings.email_templates') }}"
+                               class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div>
+                                        <h3 class="text-base font-semibold text-gray-900 transition group-hover:text-[#4E81FA] dark:text-gray-100">
+                                            {{ __('messages.email_templates') }}
+                                        </h3>
+                                        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                            {{ __('messages.email_templates_description') }}
+                                        </p>
                                     </div>
+                                    <span class="text-gray-300 transition group-hover:text-[#4E81FA] dark:text-gray-600">
+                                        <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                                        </svg>
+                                    </span>
                                 </div>
-                            @endforeach
-
-                            <div class="flex items-center gap-4">
-                                <x-primary-button>{{ __('messages.save') }}</x-primary-button>
-
-                                @if (session('status') === 'mail-templates-updated')
-                                    <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)"
-                                        class="text-sm text-gray-600 dark:text-gray-400">{{ __('messages.email_templates_saved') }}</p>
-                                @endif
-                            </div>
-                        </form>
-                    </section>
-                </div>
-            </div>
-
-            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
-                <div class="max-w-3xl">
-                    <section>
-                        <header>
-                            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
-                                {{ __('messages.application_information') }}
-                            </h2>
-
-                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                                {{ __('messages.application_information_description') }}
-                            </p>
-                        </header>
-
-                        <div class="mt-6">
-                            <dl class="divide-y divide-gray-100 dark:divide-gray-700">
-                                <div class="flex flex-col gap-1 py-4 sm:flex-row sm:items-center sm:justify-between">
-                                    <dt class="text-sm font-medium text-gray-600 dark:text-gray-400">
-                                        {{ __('messages.build_number') }}
-                                    </dt>
-                                    <dd class="text-base font-semibold text-gray-900 dark:text-gray-100">
-                                        {{ $buildNumber }}
-                                    </dd>
-                                </div>
-                            </dl>
+                                <span class="mt-auto text-sm font-medium text-[#4E81FA]">
+                                    {{ __('messages.view_details') }}
+                                </span>
+                            </a>
                         </div>
                     </section>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -88,9 +88,13 @@ Route::middleware(['auth', 'verified'])->group(function ()
     Route::get('/sales', [TicketController::class, 'sales'])->name('sales');
     Route::post('/sales/action/{sale_id}', [TicketController::class, 'handleAction'])->name('sales.action');
     
-    Route::get('/settings', [SettingsController::class, 'index'])->name('settings.index');
-    Route::patch('/settings/mail', [SettingsController::class, 'updateMail'])->name('settings.mail.update');
-    Route::patch('/settings/mail-templates', [SettingsController::class, 'updateMailTemplates'])->name('settings.mail_templates.update');
+    Route::prefix('settings')->name('settings.')->group(function () {
+        Route::get('/', [SettingsController::class, 'index'])->name('index');
+        Route::get('/email', [SettingsController::class, 'email'])->name('email');
+        Route::get('/email-templates', [SettingsController::class, 'emailTemplates'])->name('email_templates');
+        Route::patch('/email', [SettingsController::class, 'updateMail'])->name('mail.update');
+        Route::patch('/email-templates', [SettingsController::class, 'updateMailTemplates'])->name('mail_templates.update');
+    });
 
     Route::get('/account', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/account', [ProfileController::class, 'update'])->name('profile.update');


### PR DESCRIPTION
## Summary
- split the settings area into an overview page with dedicated email settings and email template sub-pages
- update admin routing, copy, and navigation to support the new settings structure
- add configurable ticket reservation/payment email templates and wire notifications to use them

## Testing
- php -l app/Http/Controllers/SettingsController.php
- php -l app/Notifications/TicketSaleNotification.php
- php -l app/Notifications/TicketPaidNotification.php
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0ef90990832e906f3add7bd76957