### PR TITLE
Handle missing schedule collections in navigation views

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,6 +1,11 @@
 <x-app-admin-layout>
+    @php
+        $schedules = isset($schedules) ? $schedules : collect();
+        $venues = isset($venues) ? $venues : collect();
+        $curators = isset($curators) ? $curators : collect();
+    @endphp
     <div class="py-5">
-        
+
         <!-- Get Started Panel -->
         @if($schedules->isEmpty() && $venues->isEmpty() && $curators->isEmpty() && auth()->user()->tickets()->count() === 0)
         <div class="mb-8">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,3 +1,9 @@
+@php
+    $schedules = isset($schedules) ? $schedules : collect();
+    $venues = isset($venues) ? $venues : collect();
+    $curators = isset($curators) ? $curators : collect();
+@endphp
+
 <a href="https://www.eventschedule.com">
     <div class="flex h-16 pt-2 shrink-0 items-center">
         <img class="h-10 w-auto" src="{{ url('images/light_logo.png') }}"


### PR DESCRIPTION
## Summary
- default schedule-related collections in the navigation partial to empty collections when absent
- apply the same guard in the home dashboard view so schedule panels load even without composed data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc5253d0c0832eafbfda9a5bb34834