### PR TITLE
Use default GitHub token for release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      commit_secret: ${{ secrets.commit_secret }}
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
@@ -44,7 +44,7 @@ jobs:
       - name: Create Release
         uses: marvinpinto/action-automatic-releases@v1.2.1
         with:
-          repo_token: "${{ secrets.commit_secret }}"
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
           prerelease: false
           title: "Latest Release"


### PR DESCRIPTION
## Summary
- remove the custom commit_secret requirement from the build workflow
- grant contents write permission and use the default GITHUB_TOKEN when creating releases

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cc88b03604832ebe1166593f45b39f