### PR TITLE
Move integration settings to settings pages

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -95,6 +95,8 @@ return [
     'back_to_settings' => 'Back to settings overview',
     'general_settings' => 'General Settings',
     'general_settings_description' => 'Set the base URL used for public links and previews.',
+    'integrations_settings' => 'Integrations & API',
+    'integrations_settings_description' => 'Connect payment providers, manage API access, and sync external calendars.',
     'application_information' => 'Application Information',
     'application_information_description' => 'Review deployment details including the current build number.',
     'build_number' => 'Build Number',

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -9,32 +9,6 @@
 
             <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
                 <div class="max-w-xl">
-                    @include('profile.partials.update-payments-form')
-                </div>
-            </div>
-
-            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
-                <div class="max-w-xl">
-                    @include('profile.partials.api-settings-form')
-                </div>
-            </div>
-
-            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
-                <div class="max-w-xl">
-                    @include('profile.partials.google-calendar-form')
-                </div>
-            </div>
-
-            @if (! config('app.hosted') && ! config('app.testing'))
-            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
-                <div class="max-w-xl">
-                    @include('profile.partials.update-app-form')
-                </div>
-            </div>
-            @endif
-
-            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
-                <div class="max-w-xl">
                     @include('profile.partials.update-password-form')
                 </div>
             </div>

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -49,6 +49,17 @@
                     </section>
                 </div>
             </div>
+
+            @if (! config('app.hosted') && ! config('app.testing'))
+                <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
+                    <div class="max-w-3xl">
+                        @include('profile.partials.update-app-form', [
+                            'version_installed' => $versionInstalled,
+                            'version_available' => $versionAvailable,
+                        ])
+                    </div>
+                </div>
+            @endif
         </div>
     </div>
 </x-app-admin-layout>

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -37,6 +37,28 @@
                                 </span>
                             </a>
 
+                            <a href="{{ route('settings.integrations') }}"
+                               class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div>
+                                        <h3 class="text-base font-semibold text-gray-900 transition group-hover:text-[#4E81FA] dark:text-gray-100">
+                                            {{ __('messages.integrations_settings') }}
+                                        </h3>
+                                        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                            {{ __('messages.integrations_settings_description') }}
+                                        </p>
+                                    </div>
+                                    <span class="text-gray-300 transition group-hover:text-[#4E81FA] dark:text-gray-600">
+                                        <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                                        </svg>
+                                    </span>
+                                </div>
+                                <span class="mt-auto text-sm font-medium text-[#4E81FA]">
+                                    {{ __('messages.view_details') }}
+                                </span>
+                            </a>
+
                             <a href="{{ route('settings.email') }}"
                                class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
                                 <div class="flex items-start justify-between gap-3">

--- a/resources/views/settings/integrations.blade.php
+++ b/resources/views/settings/integrations.blade.php
@@ -1,0 +1,48 @@
+<x-app-admin-layout>
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto space-y-6">
+            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
+                <div class="max-w-3xl">
+                    <div class="mb-6">
+                        <a href="{{ route('settings.index') }}" class="inline-flex items-center gap-2 text-sm font-medium text-[#4E81FA] hover:text-[#365fcc]">
+                            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+                            </svg>
+                            {{ __('messages.back_to_settings') }}
+                        </a>
+                    </div>
+
+                    <section>
+                        <header>
+                            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+                                {{ __('messages.integrations_settings') }}
+                            </h2>
+
+                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                {{ __('messages.integrations_settings_description') }}
+                            </p>
+                        </header>
+                    </section>
+                </div>
+            </div>
+
+            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
+                <div class="max-w-3xl">
+                    @include('profile.partials.update-payments-form', ['user' => $user])
+                </div>
+            </div>
+
+            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
+                <div class="max-w-3xl">
+                    @include('profile.partials.api-settings-form')
+                </div>
+            </div>
+
+            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
+                <div class="max-w-3xl">
+                    @include('profile.partials.google-calendar-form')
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-admin-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -93,6 +93,7 @@ Route::middleware(['auth', 'verified'])->group(function ()
     Route::prefix('settings')->name('settings.')->group(function () {
         Route::get('/', [SettingsController::class, 'index'])->name('index');
         Route::get('/general', [SettingsController::class, 'general'])->name('general');
+        Route::get('/integrations', [SettingsController::class, 'integrations'])->name('integrations');
         Route::get('/email', [SettingsController::class, 'email'])->name('email');
         Route::get('/email-templates', [SettingsController::class, 'emailTemplates'])->name('email_templates');
         Route::patch('/general', [SettingsController::class, 'updateGeneral'])->name('general.update');

--- a/tests/Browser/Traits/AccountSetupTrait.php
+++ b/tests/Browser/Traits/AccountSetupTrait.php
@@ -99,7 +99,8 @@ trait AccountSetupTrait
      */
     protected function enableApi(Browser $browser): string
     {
-        $browser->visit('/account')
+        $browser->visit('/settings/integrations')
+                ->waitFor('#enable_api', 5)
                 ->scrollIntoView('#enable_api');
         $browser->script("document.getElementById('enable_api').checked = true;");
         $browser->press('Save')


### PR DESCRIPTION
## Summary
- remove payment, API, Google Calendar, and self-update panels from the account page so it only shows profile & security actions
- add an Integrations settings page and route that hosts the payment, API, and Google Calendar forms along with updated translations and navigation tile
- surface the self-update card on the general settings page and adjust controller redirects so integration actions return to settings

## Testing
- `php artisan test` *(fails: missing vendor directory; composer install requires GitHub token in this environment)*
- `composer install` *(fails: GitHub authentication required to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cc94e0e6a4832ea2033d433914a0c3