### PR TITLE
Fix admin calendar edit links to use configured public URL

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -96,3 +96,37 @@ if (!function_exists('is_rtl')) {
         return in_array($locale, ['ar', 'he']);
     }
 }
+
+if (!function_exists('app_public_url')) {
+    /**
+     * Resolve the public application URL from settings when available.
+     */
+    function app_public_url(): string
+    {
+        static $cachedUrl = null;
+
+        if ($cachedUrl !== null) {
+            return $cachedUrl;
+        }
+
+        $url = config('app.url');
+
+        try {
+            if (\Illuminate\Support\Facades\Schema::hasTable('settings')) {
+                $generalSettings = \App\Models\Setting::forGroup('general');
+
+                if (!empty($generalSettings['public_url'])) {
+                    $url = $generalSettings['public_url'];
+                }
+            }
+        } catch (\Throwable $exception) {
+            // Ignore any issues while resolving the URL and fall back to the config value.
+        }
+
+        if (empty($url)) {
+            $url = url('/');
+        }
+
+        return $cachedUrl = rtrim($url, '/');
+    }
+}

--- a/resources/views/role/partials/calendar.blade.php
+++ b/resources/views/role/partials/calendar.blade.php
@@ -6,6 +6,7 @@
     $totalDays = $endOfMonth->diffInDays($startOfMonth) + 1;
     $totalWeeks = ceil($totalDays / 7);
     $unavailable = [];
+    $publicUrl = app_public_url();
 
     // Always initialize as arrays
     $eventGroupIds = [];
@@ -57,8 +58,10 @@
             'guest_url' => $event->getGuestUrl(isset($subdomain) ? $subdomain : '', ''),
             'image_url' => $event->getImageUrl(),
             'can_edit' => auth()->user() && auth()->user()->canEditEvent($event),
-            'edit_url' => auth()->user() && auth()->user()->canEditEvent($event) 
-                ? (isset($role) ? config('app.url') . route('event.edit', ['subdomain' => $role->subdomain, 'hash' => App\Utils\UrlUtils::encodeId($event->id)], false) : config('app.url') . route('event.edit_admin', ['hash' => App\Utils\UrlUtils::encodeId($event->id)], false))
+            'edit_url' => auth()->user() && auth()->user()->canEditEvent($event)
+                ? (isset($role)
+                    ? $publicUrl . route('event.edit', ['subdomain' => $role->subdomain, 'hash' => App\Utils\UrlUtils::encodeId($event->id)], false)
+                    : $publicUrl . route('event.edit_admin', ['hash' => App\Utils\UrlUtils::encodeId($event->id)], false))
                 : null,
         ];
     }


### PR DESCRIPTION
## Summary
- add an `app_public_url()` helper that prefers the configured public URL stored in settings
- update the admin calendar event payload to build edit links with the resolved public URL so they no longer point to localhost

## Testing
- composer install *(fails: requires GitHub token for symfony/polyfill-mbstring)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9f23bd14832ebbfdcddc2ad47dbf