### PR TITLE
Increase upload limits to 500 MB

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,6 @@
+# Allow uploads up to 500 MB (524,288,000 bytes)
+LimitRequestBody 524288000
+
 <IfModule mod_rewrite.c>
   RewriteEngine On
   RewriteRule "^.env" - [F,L]

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,3 +1,6 @@
+# Allow uploads up to 500 MB (524,288,000 bytes)
+LimitRequestBody 524288000
+
 <IfModule mod_rewrite.c>
     <IfModule mod_negotiation.c>
         Options -MultiViews -Indexes

--- a/public/.user.ini
+++ b/public/.user.ini
@@ -1,4 +1,4 @@
-post_max_size=20M
-upload_max_filesize=5M
+post_max_size=500M
+upload_max_filesize=500M
 max_input_time=90
 max_execution_time=90


### PR DESCRIPTION
## Summary
- raise PHP upload and post limits to 500 MB via the project .user.ini
- add Apache request body limits allowing 500 MB uploads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccb6afdbb8832e895fac45d03bbcb1