### PR TITLE
Adjust CSP for custom domains and fix test email fetch

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -44,6 +44,8 @@ class SecurityHeaders
         
         $isLocal = app()->environment('local');
         $host = $request->getHost();
+        $httpHost = "http://{$host}";
+        $httpsHost = "https://{$host}";
         
         // Build CSP based on environment
         if ($isLocal) {
@@ -63,11 +65,11 @@ class SecurityHeaders
             // Stricter CSP for production
             $csp = [
                 "default-src 'self'",
-                "script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googleapis.com *.gstatic.com *.googletagmanager.com *.stripe.com unpkg.com js.sentry-cdn.com browser.sentry-cdn.com *.sentry.io",
-                "style-src 'self' 'unsafe-inline' *.googleapis.com *.gstatic.com *.bootstrapcdn.com rsms.me",
-                "img-src 'self' data: *.googleapis.com *.gstatic.com *.googletagmanager.com *.stripe.com *.ytimg.com eventschedule.nyc3.cdn.digitaloceanspaces.com",
-                "font-src 'self' data: *.googleapis.com *.gstatic.com *.bootstrapcdn.com rsms.me",
-                "connect-src 'self' *.googleapis.com *.google-analytics.com *.googletagmanager.com *.jsdelivr.net *.stripe.com *.sentry.io",
+                "script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googleapis.com *.gstatic.com *.googletagmanager.com *.stripe.com unpkg.com js.sentry-cdn.com browser.sentry-cdn.com *.sentry.io {$httpsHost} {$httpHost}",
+                "style-src 'self' 'unsafe-inline' *.googleapis.com *.gstatic.com *.bootstrapcdn.com rsms.me {$httpsHost} {$httpHost}",
+                "img-src 'self' data: *.googleapis.com *.gstatic.com *.googletagmanager.com *.stripe.com *.ytimg.com eventschedule.nyc3.cdn.digitaloceanspaces.com {$httpsHost} {$httpHost}",
+                "font-src 'self' data: *.googleapis.com *.gstatic.com *.bootstrapcdn.com rsms.me {$httpsHost} {$httpHost}",
+                "connect-src 'self' *.googleapis.com *.google-analytics.com *.googletagmanager.com *.jsdelivr.net *.stripe.com *.sentry.io {$httpsHost} {$httpHost}",
                 "frame-src 'self' *.eventschedule.com *.stripe.com *.youtube.com *.googletagmanager.com",
                 "object-src 'none'",
                 "base-uri 'self'",

--- a/resources/views/settings/email.blade.php
+++ b/resources/views/settings/email.blade.php
@@ -36,7 +36,7 @@
                                     formData.delete('_method');
 
                                     try {
-                                        const response = await fetch('{{ route('settings.mail.test') }}', {
+                                        const response = await fetch('{{ route('settings.mail.test', absolute: false) }}', {
                                             method: 'POST',
                                             headers: {
                                                 'Accept': 'application/json',


### PR DESCRIPTION
## Summary
- extend the production content security policy to explicitly allow the current host over http and https for scripts, styles, images, fonts, and api calls
- update the test email fetch in the settings view to use a relative route so it no longer forces an http scheme

## Testing
- composer install *(fails: requires a GitHub token to download aws/aws-crt-php)*

------
https://chatgpt.com/codex/tasks/task_e_68cd59b78460832e8721d95005af0355