### PR TITLE
Fix HTMLPurifier cache directory permissions

### DIFF
--- a/app/Utils/MarkdownUtils.php
+++ b/app/Utils/MarkdownUtils.php
@@ -5,6 +5,7 @@ namespace App\Utils;
 use League\CommonMark\CommonMarkConverter;
 use HTMLPurifier;
 use HTMLPurifier_Config;
+use Illuminate\Support\Facades\File;
 
 class MarkdownUtils
 {
@@ -24,8 +25,16 @@ class MarkdownUtils
         $html = $converter->convertToHtml($markdown);
         
         $config = HTMLPurifier_Config::createDefault();
+
+        $cachePath = storage_path('app/htmlpurifier');
+
+        if (! File::exists($cachePath)) {
+            File::makeDirectory($cachePath, 0755, true);
+        }
+
+        $config->set('Cache.SerializerPath', $cachePath);
         $purifier = new HTMLPurifier($config);
-        
+
         return $purifier->purify($html);
     }
 }


### PR DESCRIPTION
## Summary
- configure HTMLPurifier to use a writable cache directory under storage
- ensure the serializer directory exists before purifying markdown content

## Testing
- ./vendor/bin/phpunit *(fails: file not found in repository checkout)*

------
https://chatgpt.com/codex/tasks/task_e_68cd65d4316c832e82f2e3bad502196f