### PR TITLE
Add consolidated pages list view

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -639,6 +639,24 @@ class RoleController extends Controller
         return view('role/index', $data);
     }
 
+    public function pages(Request $request)
+    {
+        $roles = $request->user()
+            ->member()
+            ->withCount([
+                'events',
+                'followers',
+                'members as team_members_count',
+            ])
+            ->orderBy('type')
+            ->orderBy('name')
+            ->get();
+
+        return view('role.pages', [
+            'roles' => $roles,
+        ]);
+    }
+
     public function venues(Request $request)
     {
         return $this->renderRoleListing($request, 'venues');

--- a/resources/lang/ar/messages.php
+++ b/resources/lang/ar/messages.php
@@ -3,6 +3,10 @@
 return [
     'home' => 'الرئيسية',
     'venues' => 'الأماكن',
+    'pages' => 'الصفحات',
+    'manage_pages_description' => 'إدارة جميع صفحات الجدول الخاصة بك في مكان واحد.',
+    'no_pages_listed' => 'لم يتم إنشاء صفحات بعد.',
+    'create_first_page_prompt' => 'ابدأ بإنشاء صفحة موهبة أو مكان أو منسق.',
     'event_deleted' => 'تم حذف الحدث بنجاح',
     'edit_event' => 'تعديل الحدث',
     'add_event' => 'إضافة حدث',

--- a/resources/lang/de/messages.php
+++ b/resources/lang/de/messages.php
@@ -3,6 +3,10 @@
 return [
     'home' => 'Startseite',
     'venues' => 'Veranstaltungsorte',
+    'pages' => 'Seiten',
+    'manage_pages_description' => 'Verwalte alle deine Zeitplan-Seiten an einem Ort.',
+    'no_pages_listed' => 'Noch keine Seiten erstellt.',
+    'create_first_page_prompt' => 'Beginne mit dem Erstellen einer Talent-, Veranstaltungsort- oder Kuratorseite.',
     'event_deleted' => 'Veranstaltung erfolgreich gelöscht',
     'edit_event' => 'Veranstaltung bearbeiten',
     'add_event' => 'Veranstaltung hinzufügen',

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -3,6 +3,10 @@
 return [
     'home' => 'Home',
     'venues' => 'Venues',
+    'pages' => 'Pages',
+    'manage_pages_description' => 'Manage all of your schedule pages in one place.',
+    'no_pages_listed' => 'No pages created yet.',
+    'create_first_page_prompt' => 'Start by creating a talent, venue, or curator page.',
     'manage_role_listings_venue' => 'Keep venue details and contacts in one place.',
     'manage_role_listings_curator' => 'Track the curators you collaborate with across events.',
     'manage_role_listings_talent' => 'Manage your talent schedules and booking contacts.',

--- a/resources/lang/es/messages.php
+++ b/resources/lang/es/messages.php
@@ -3,6 +3,10 @@
 return [
     'home' => 'Inicio',
     'venues' => 'Lugares',
+    'pages' => 'Páginas',
+    'manage_pages_description' => 'Administra todas tus páginas de horarios en un solo lugar.',
+    'no_pages_listed' => 'Aún no hay páginas creadas.',
+    'create_first_page_prompt' => 'Comienza creando una página de talento, sede o curador.',
     'event_deleted' => 'Evento eliminado con éxito',
     'edit_event' => 'Editar Evento',
     'add_event' => 'Agregar Evento',

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -3,6 +3,10 @@
 return [
     'home' => 'Accueil',
     'venues' => 'Lieux',
+    'pages' => 'Pages',
+    'manage_pages_description' => 'Gérez toutes vos pages de planning en un seul endroit.',
+    'no_pages_listed' => 'Aucune page créée pour le moment.',
+    'create_first_page_prompt' => 'Commencez par créer une page talent, lieu ou curateur.',
     'event_deleted' => 'Événement supprimé avec succès',
     'edit_event' => 'Modifier l\'Événement',
     'add_event' => 'Ajouter un Événement',

--- a/resources/lang/he/messages.php
+++ b/resources/lang/he/messages.php
@@ -4,6 +4,10 @@
 return [
     'home' => 'דף הבית',
     'venues' => 'מקומות',
+    'pages' => 'דפים',
+    'manage_pages_description' => 'נהל את כל דפי לוח הזמנים שלך במקום אחד.',
+    'no_pages_listed' => 'עדיין לא נוצרו דפים.',
+    'create_first_page_prompt' => 'התחל ביצירת דף כישרון, מקום או אוצר.',
     'event_deleted' => 'האירוע נמחק בהצלחה',
     'edit_event' => 'ערוך אירוע',
     'add_event' => 'הוסף אירוע',

--- a/resources/lang/it/messages.php
+++ b/resources/lang/it/messages.php
@@ -3,6 +3,10 @@
 return [
     'home' => 'Home',
     'venues' => 'Luoghi',
+    'pages' => 'Pagine',
+    'manage_pages_description' => 'Gestisci tutte le tue pagine di calendario in un unico posto.',
+    'no_pages_listed' => 'Nessuna pagina ancora creata.',
+    'create_first_page_prompt' => 'Inizia creando una pagina per talento, luogo o curatore.',
     'event_deleted' => 'Evento eliminato con successo',
     'edit_event' => 'Modifica Evento',
     'add_event' => 'Aggiungi Evento',

--- a/resources/lang/nl/messages.php
+++ b/resources/lang/nl/messages.php
@@ -3,6 +3,10 @@
 return [
     'home' => 'Home',
     'venues' => 'Locaties',
+    'pages' => 'Pagina\'s',
+    'manage_pages_description' => 'Beheer al je planningspagina\'s op één plek.',
+    'no_pages_listed' => 'Nog geen pagina\'s aangemaakt.',
+    'create_first_page_prompt' => 'Begin met het maken van een pagina voor talent, locatie of curator.',
     'event_deleted' => 'Evenement succesvol verwijderd',
     'edit_event' => 'Evenement Bewerken',
     'add_event' => 'Evenement Toevoegen',

--- a/resources/lang/pt/messages.php
+++ b/resources/lang/pt/messages.php
@@ -3,6 +3,10 @@
 return [
     'home' => 'Início',
     'venues' => 'Locais',
+    'pages' => 'Páginas',
+    'manage_pages_description' => 'Gerencie todas as suas páginas de agenda em um só lugar.',
+    'no_pages_listed' => 'Nenhuma página criada ainda.',
+    'create_first_page_prompt' => 'Comece criando uma página de talento, local ou curador.',
     'event_deleted' => 'Evento excluído com sucesso',
     'edit_event' => 'Editar Evento',
     'add_event' => 'Adicionar Evento',

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -38,6 +38,17 @@
                 </li>
 
                 <li>
+                    <a href="{{ route('role.pages') }}"
+                        class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->routeIs('role.pages') ? 'bg-gray-800 text-white' : '' }}">
+                        <svg class="h-6 w-6 shrink-0" viewBox="0 0 24 24"
+                            fill="{{ request()->routeIs('role.pages') ? '#ccc' : '#666' }}" aria-hidden="true">
+                            <path d="M6 3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h9.5a2 2 0 0 0 2-2V8.5L13 3H6zm7 1.5L17.5 9H13V4.5z" />
+                        </svg>
+                        {{ __('messages.pages') }}
+                    </a>
+                </li>
+
+                <li>
                     <a href="{{ route('role.venues') }}"
                         class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->routeIs('role.venues') ? 'bg-gray-800 text-white' : '' }}">
                         <svg class="h-6 w-6 shrink-0" viewBox="0 0 24 24" fill="none"

--- a/resources/views/role/pages.blade.php
+++ b/resources/views/role/pages.blade.php
@@ -1,0 +1,182 @@
+<x-app-admin-layout>
+    @php
+        $typeStyles = [
+            'talent' => 'bg-purple-50 text-purple-700 ring-purple-600/20 dark:bg-purple-500/20 dark:text-purple-200 dark:ring-purple-400/40',
+            'venue' => 'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-500/20 dark:text-emerald-200 dark:ring-emerald-400/40',
+            'curator' => 'bg-amber-50 text-amber-700 ring-amber-600/20 dark:bg-amber-500/20 dark:text-amber-200 dark:ring-amber-400/40',
+        ];
+    @endphp
+
+    <div class="py-12">
+        <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+            <div class="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <h1 class="text-3xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">{{ __('messages.pages') }}</h1>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">{{ __('messages.manage_pages_description') }}</p>
+                </div>
+                <div class="flex flex-wrap items-center gap-3">
+                    <a
+                        href="{{ route('new', ['type' => 'talent']) }}"
+                        class="inline-flex items-center gap-2 rounded-full bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-purple-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-600"
+                    >
+                        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M19 13H13V19H11V13H5V11H11V5H13V11H19V13Z" />
+                        </svg>
+                        {{ __('messages.new_talent') }}
+                    </a>
+                    <a
+                        href="{{ route('new', ['type' => 'venue']) }}"
+                        class="inline-flex items-center gap-2 rounded-full bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+                    >
+                        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M19 13H13V19H11V13H5V11H11V5H13V11H19V13Z" />
+                        </svg>
+                        {{ __('messages.new_venue') }}
+                    </a>
+                    <a
+                        href="{{ route('new', ['type' => 'curator']) }}"
+                        class="inline-flex items-center gap-2 rounded-full bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500"
+                    >
+                        <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path d="M19 13H13V19H11V13H5V11H11V5H13V11H19V13Z" />
+                        </svg>
+                        {{ __('messages.new_curator') }}
+                    </a>
+                </div>
+            </div>
+
+            @if ($roles->isNotEmpty())
+                <div class="mt-8 -mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+                    <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+                        <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg dark:ring-white/10">
+                            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                                <thead class="bg-gray-50 dark:bg-gray-900/60">
+                                    <tr>
+                                        <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-gray-100 sm:pl-6">
+                                            {{ __('messages.name') }}
+                                        </th>
+                                        <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
+                                            {{ __('messages.type') }}
+                                        </th>
+                                        <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
+                                            {{ __('messages.events') }}
+                                        </th>
+                                        <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
+                                            {{ __('messages.followers') }}
+                                        </th>
+                                        <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
+                                            {{ __('messages.status') }}
+                                        </th>
+                                        <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
+                                            {{ __('messages.team') }}
+                                        </th>
+                                        <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
+                                            <span class="sr-only">{{ __('messages.actions') }}</span>
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
+                                    @foreach ($roles as $role)
+                                        @php
+                                            $type = strtolower($role->type);
+                                            $badgeClass = $typeStyles[$type] ?? 'bg-gray-100 text-gray-700 ring-gray-500/20 dark:bg-gray-700 dark:text-gray-200 dark:ring-gray-500/30';
+                                            $statusLabel = $role->is_unlisted ? __('messages.unlisted') : __('messages.public');
+                                            $publicUrl = $role->getGuestUrl();
+                                            $displayUrl = $publicUrl ? str_replace(['https://', 'http://'], '', $publicUrl) : $role->subdomain;
+                                        @endphp
+                                        <tr class="transition-colors duration-150 hover:bg-gray-50 dark:hover:bg-gray-700/60">
+                                            <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 dark:text-gray-100 sm:pl-6">
+                                                <div class="flex flex-col">
+                                                    <span>{{ $role->getDisplayName(false) }}</span>
+                                                    <span class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ $displayUrl }}</span>
+                                                </div>
+                                            </td>
+                                            <td class="whitespace-nowrap px-3 py-4 text-sm">
+                                                <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ring-inset {{ $badgeClass }}">
+                                                    {{ __('messages.' . $type) }}
+                                                </span>
+                                            </td>
+                                            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                                {{ number_format($role->events_count) }}
+                                            </td>
+                                            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                                {{ number_format($role->followers_count) }}
+                                            </td>
+                                            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                                {{ $statusLabel }}
+                                            </td>
+                                            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-300">
+                                                {{ number_format($role->team_members_count ?? 0) }}
+                                            </td>
+                                            <td class="whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                                                <div class="flex items-center justify-end gap-2">
+                                                    <a
+                                                        href="{{ route('role.view_admin', ['subdomain' => $role->subdomain, 'tab' => 'schedule']) }}"
+                                                        class="inline-flex items-center rounded-md bg-white px-3 py-1.5 text-sm font-semibold text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 transition hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                                                    >
+                                                        {{ __('messages.manage') }}
+                                                    </a>
+                                                    @if ($publicUrl)
+                                                        <a
+                                                            href="{{ $publicUrl }}"
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                            class="inline-flex items-center rounded-md bg-[#4E81FA] px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-[#3b6ae0] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4E81FA]"
+                                                        >
+                                                            {{ __('messages.view') }}
+                                                        </a>
+                                                    @endif
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            @else
+                <div class="mt-12 flex flex-col items-center justify-center rounded-2xl border border-dashed border-gray-300 bg-white p-12 text-center dark:border-gray-700 dark:bg-gray-800">
+                    <div class="flex h-14 w-14 items-center justify-center rounded-full bg-[#4E81FA]/10">
+                        <svg class="h-6 w-6 text-[#4E81FA]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 3H15a1.5 1.5 0 011.5 1.5V7.5H19.5A1.5 1.5 0 0121 9V19.5A1.5 1.5 0 0119.5 21H9" />
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 3A1.5 1.5 0 003 4.5v15A1.5 1.5 0 004.5 21h10.5A1.5 1.5 0 0016.5 19.5V18" />
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h6m-6 3h6m-6 3H12" />
+                        </svg>
+                    </div>
+                    <h3 class="mt-6 text-lg font-semibold text-gray-900 dark:text-gray-100">{{ __('messages.no_pages_listed') }}</h3>
+                    <p class="mt-2 max-w-md text-sm text-gray-600 dark:text-gray-400">{{ __('messages.create_first_page_prompt') }}</p>
+                    <div class="mt-6 flex flex-wrap items-center justify-center gap-3">
+                        <a
+                            href="{{ route('new', ['type' => 'talent']) }}"
+                            class="inline-flex items-center gap-2 rounded-full bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-purple-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-600"
+                        >
+                            <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                <path d="M19 13H13V19H11V13H5V11H11V5H13V11H19V13Z" />
+                            </svg>
+                            {{ __('messages.new_talent') }}
+                        </a>
+                        <a
+                            href="{{ route('new', ['type' => 'venue']) }}"
+                            class="inline-flex items-center gap-2 rounded-full bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+                        >
+                            <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                <path d="M19 13H13V19H11V13H5V11H11V5H13V11H19V13Z" />
+                            </svg>
+                            {{ __('messages.new_venue') }}
+                        </a>
+                        <a
+                            href="{{ route('new', ['type' => 'curator']) }}"
+                            class="inline-flex items-center gap-2 rounded-full bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500"
+                        >
+                            <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                <path d="M19 13H13V19H11V13H5V11H11V5H13V11H19V13Z" />
+                            </svg>
+                            {{ __('messages.new_curator') }}
+                        </a>
+                    </div>
+                </div>
+            @endif
+        </div>
+    </div>
+</x-app-admin-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -91,6 +91,7 @@ Route::middleware(['auth', 'verified'])->group(function ()
     Route::get('/search-events/{subdomain}', [RoleController::class, 'searchEvents'])->name('role.search_events');
     Route::get('/admin-edit-event/{hash}', [EventController::class, 'editAdmin'])->name('event.edit_admin');
     Route::get('/following', [RoleController::class, 'following'])->name('following');
+    Route::get('/pages', [RoleController::class, 'pages'])->name('role.pages');
     Route::get('/tickets', [TicketController::class, 'tickets'])->name('tickets');
     Route::get('/sales', [TicketController::class, 'sales'])->name('sales');
     Route::post('/sales/action/{sale_id}', [TicketController::class, 'handleAction'])->name('sales.action');


### PR DESCRIPTION
## Summary
- expose a new `role.pages` route and controller action that aggregates the member roles with counts for events, followers, and team size
- add an admin pages table with quick-create buttons, status indicators, and an empty state message
- surface the view in the sidebar navigation and translate the new copy across the available locales

## Testing
- `php artisan test` *(fails: vendor directory missing; composer install blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cd971c8d84832e9e659cefaebfaa51