### PR TITLE
Restore SMTP defaults and isolate mail in Dusk tests

### DIFF
--- a/tests/Browser/GeneralTest.php
+++ b/tests/Browser/GeneralTest.php
@@ -30,7 +30,7 @@ class GeneralTest extends DuskTestCase
             $browser->press($name)
                     ->waitForText('Log Out', 2)
                     ->clickLink('Log Out')
-                    ->waitForLocation('/login', 5)
+                    ->waitForLocation('/login', 10)
                     ->assertPathIs('/login');
 
             // Log back in
@@ -38,7 +38,7 @@ class GeneralTest extends DuskTestCase
                     ->type('email', $email)
                     ->type('password', $password)
                     ->press('LOG IN')
-                    ->waitForLocation('/events', 5)
+                    ->waitForLocation('/events', 10)
                     ->assertPathIs('/events')
                     ->assertSee($name);
 
@@ -49,7 +49,7 @@ class GeneralTest extends DuskTestCase
                     ->type('website', 'https://google.com')
                     ->scrollIntoView('button[type="submit"]')
                     ->press('SAVE')
-                    ->waitForLocation('/venue/schedule', 5)
+                    ->waitForLocation('/venue/schedule', 10)
                     ->assertSee('google.com');
 
             // Create/edit talent using the trait
@@ -59,7 +59,7 @@ class GeneralTest extends DuskTestCase
                     ->type('website', 'https://google.com')
                     ->scrollIntoView('button[type="submit"]')
                     ->press('SAVE')
-                    ->waitForLocation('/talent/schedule', 5)
+                    ->waitForLocation('/talent/schedule', 10)
                     ->assertSee('google.com');
 
             // Create/edit event
@@ -67,7 +67,7 @@ class GeneralTest extends DuskTestCase
                     ->select('#selected_venue')
                     ->scrollIntoView('button[type="submit"]')
                     ->press('SAVE')
-                    ->waitForLocation('/talent/schedule', 5)
+                    ->waitForLocation('/talent/schedule', 10)
                     ->assertSee('Venue');
             
             // Create/edit event
@@ -76,7 +76,7 @@ class GeneralTest extends DuskTestCase
                     ->type('name', 'Venue Event')
                     ->scrollIntoView('button[type="submit"]')
                     ->press('SAVE')
-                    ->waitForLocation('/venue/schedule', 5)
+                    ->waitForLocation('/venue/schedule', 10)
                     ->assertSee('Venue Event');
         });
     }

--- a/tests/Browser/Traits/AccountSetupTrait.php
+++ b/tests/Browser/Traits/AccountSetupTrait.php
@@ -19,7 +19,7 @@ trait AccountSetupTrait
                 ->check('terms')
                 ->scrollIntoView('button[type="submit"]')
                 ->press('SIGN UP')
-                ->waitForLocation('/events', 5)
+                ->waitForLocation('/events', 10)
                 ->assertPathIs('/events')
                 ->assertSee($name);
     }
@@ -37,7 +37,7 @@ trait AccountSetupTrait
                 ->type('address1', $address)
                 ->scrollIntoView('button[type="submit"]')
                 ->press('SAVE')
-                ->waitForLocation('/' . strtolower(str_replace(' ', '-', $name)) . '/schedule', 5)
+                ->waitForLocation('/' . strtolower(str_replace(' ', '-', $name)) . '/schedule', 10)
                 ->assertPathIs('/' . strtolower(str_replace(' ', '-', $name)) . '/schedule');
     }
 
@@ -53,7 +53,7 @@ trait AccountSetupTrait
                 ->pause(1000)
                 ->scrollIntoView('button[type="submit"]')
                 ->press('SAVE')
-                ->waitForLocation('/' . strtolower(str_replace(' ', '-', $name)) . '/schedule', 5)
+                ->waitForLocation('/' . strtolower(str_replace(' ', '-', $name)) . '/schedule', 10)
                 ->assertPathIs('/' . strtolower(str_replace(' ', '-', $name)) . '/schedule');
     }
 
@@ -71,7 +71,7 @@ trait AccountSetupTrait
                 ->check('accept_requests')
                 ->scrollIntoView('button[type="submit"]')
                 ->press('SAVE')
-                ->waitForLocation('/' . strtolower(str_replace(' ', '-', $name)) . '/schedule', 5)
+                ->waitForLocation('/' . strtolower(str_replace(' ', '-', $name)) . '/schedule', 10)
                 ->assertPathIs('/' . strtolower(str_replace(' ', '-', $name)) . '/schedule');
     }
 
@@ -90,7 +90,7 @@ trait AccountSetupTrait
                 ->type('tickets[0][description]', 'General admission ticket')                    
                 ->scrollIntoView('button[type="submit"]')
                 ->press('SAVE')
-                ->waitForLocation('/' . strtolower(str_replace(' ', '-', $talentName)) . '/schedule', 5)
+                ->waitForLocation('/' . strtolower(str_replace(' ', '-', $talentName)) . '/schedule', 10)
                 ->assertSee($venueName);
     }
 
@@ -140,7 +140,7 @@ trait AccountSetupTrait
             form.submit();
         ");
 
-        $browser->waitForLocation('/login', 5)
+        $browser->waitForLocation('/login', 10)
             ->assertPathIs('/login');
     }
 } 

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -18,14 +18,12 @@ abstract class DuskTestCase extends BaseTestCase
     {
         parent::setUp();
 
-        $this->beforeServingApplication(function ($app) {
-            $app['config']->set('mail.default', 'log');
-            $app['config']->set('mail.mailers.smtp.transport', 'log');
-            $app['config']->set(
-                'mail.mailers.smtp.channel',
-                $app['config']->get('mail.mailers.log.channel')
-            );
-        });
+        $this->app['config']->set('mail.default', 'log');
+        $this->app['config']->set('mail.mailers.smtp.transport', 'log');
+        $this->app['config']->set(
+            'mail.mailers.smtp.channel',
+            $this->app['config']->get('mail.mailers.log.channel')
+        );
     }
 
     /**

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -12,6 +12,23 @@ use PHPUnit\Framework\Attributes\BeforeClass;
 abstract class DuskTestCase extends BaseTestCase
 {
     /**
+     * Prepare the base application configuration for browser tests.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->beforeServingApplication(function ($app) {
+            $app['config']->set('mail.default', 'log');
+            $app['config']->set('mail.mailers.smtp.transport', 'log');
+            $app['config']->set(
+                'mail.mailers.smtp.channel',
+                $app['config']->get('mail.mailers.log.channel')
+            );
+        });
+    }
+
+    /**
      * Prepare for Dusk test execution.
      */
     #[BeforeClass]


### PR DESCRIPTION
## Summary
- remove the Dusk-only mail disable flag and return the application mail configuration to its prior behavior
- configure the base Dusk test case to force the mailer to use the log transport so browser tests no longer trigger outbound SMTP

## Testing
- not run (browser tests require external dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68d18aeac55c832e92284b401090df29