### PR TITLE
Ensure event URLs are unique and drop date query

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -365,7 +365,10 @@ class TicketController extends Controller
 
         $event = $sale->event;
         
-        return redirect($event->getGuestUrl($subdomain, $sale->event_date) . '&tickets=true');
+        $eventUrl = $event->getGuestUrl($subdomain, $sale->event_date);
+        $separator = Str::contains($eventUrl, '?') ? '&' : '?';
+
+        return redirect($eventUrl . $separator . 'tickets=true');
     }
 
     public function paymentUrlSuccess($sale_id)
@@ -396,7 +399,10 @@ class TicketController extends Controller
 
         $event = $sale->event;
         
-        return redirect($event->getGuestUrl($sale->subdomain, $sale->event_date) . '&tickets=true');
+        $eventUrl = $event->getGuestUrl($sale->subdomain, $sale->event_date);
+        $separator = Str::contains($eventUrl, '?') ? '&' : '?';
+
+        return redirect($eventUrl . $separator . 'tickets=true');
     }
 
     public function scan()

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -436,21 +436,13 @@ class Event extends Model
             $subdomain = $this->creatorRole ? $this->creatorRole->subdomain : null;
         }
 
-        $slug = $this->slug;
+        $slug = $this->slug ?: ($this->id ? UrlUtils::encodeId($this->id) : null);
 
-        if ($venueSubdomain && $roleSubdomain) {
-            $slug = $venueSubdomain == $subdomain ? $roleSubdomain : $venueSubdomain;
-        }
-        
-        // TODO supoprt custom_slug
-        
-        if ($date === null && $this->starts_at) {
-            $date = Carbon::createFromFormat('Y-m-d H:i:s', $this->starts_at, 'UTC')->format('Y-m-d');
-        }
+        // TODO support custom_slug
 
         $data = [
-            'subdomain' => $subdomain, 
-            'slug' => $slug, 
+            'subdomain' => $subdomain,
+            'slug' => $slug,
         ];
 
         if ($date) {

--- a/resources/views/role/partials/calendar.blade.php
+++ b/resources/views/role/partials/calendar.blade.php
@@ -538,9 +538,13 @@ const calendarApp = createApp({
         getEventUrl(event, date) {
             let url = event.guest_url;
             let queryParams = [];
-            
+
             if (date) {
-                queryParams.push('date=' + date);
+                const eventDate = new Date(date);
+                if (!Number.isNaN(eventDate.getTime())) {
+                    queryParams.push('month=' + (eventDate.getMonth() + 1));
+                    queryParams.push('year=' + eventDate.getFullYear());
+                }
             }
             
             // Preserve current filter values


### PR DESCRIPTION
## Summary
- generate unique slugs for new events and fill missing slugs when saving
- keep event guest URLs slug-based and stop appending the default date query string
- update schedule links and ticket redirects to work without the date parameter while preserving filter context

## Testing
- Unable to run tests (composer install requires a GitHub token)


------
https://chatgpt.com/codex/tasks/task_e_68d1a8af5aec832e8352236d35cab278