### PR TITLE
Bump installed version for release v1.0.33

### DIFF
--- a/config/self-update.php
+++ b/config/self-update.php
@@ -28,7 +28,7 @@ return [
     |
     */
 
-    'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', 'v1.0.32-dfiore1230'),
+    'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', 'v1.0.33-dfiore1230'),
 
     'github_defaults' => [
         'vendor' => $defaultGithubVendor,


### PR DESCRIPTION
## Summary
- bump the default self-updater installed version to v1.0.33

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1cae9bdf8832eb32fdaf35b036f8c