### PR TITLE
Purge mailer cache when updating mail settings

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -430,6 +430,7 @@ class SettingsController extends Controller
             ], 500);
         } finally {
             $this->applyMailConfig($originalSettings);
+            $this->purgeResolvedMailer($originalSettings['mailer'] ?? null);
         }
     }
 
@@ -771,6 +772,21 @@ class SettingsController extends Controller
             'mail.from.address' => $settings['from_address'],
             'mail.from.name' => $settings['from_name'],
         ]);
+
+        $this->purgeResolvedMailer($settings['mailer'] ?? null);
+    }
+
+    protected function purgeResolvedMailer(?string $mailer = null): void
+    {
+        if (app()->bound('mail.manager')) {
+            app('mail.manager')->purge($mailer);
+        }
+
+        app()->forgetInstance('mailer');
+
+        if (method_exists(app(), 'forgetResolvedInstance')) {
+            app()->forgetResolvedInstance('mailer');
+        }
     }
 
     protected function nullableTrim(?string $value): ?string


### PR DESCRIPTION
## Summary
- purge the cached mailer and forget the resolved binding after applying mail settings
- reuse the purge logic when restoring mail configuration after sending a test email
- add a feature test that ensures the mailer transport picks up updated SMTP host information during test sends

## Testing
- php -l app/Http/Controllers/SettingsController.php
- php -l tests/Feature/SettingsTest.php
- ./vendor/bin/phpunit --filter SettingsTest --testdox *(fails: vendor/bin/phpunit missing because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1dc2eff8c832e9bbf74c95594ca56