### PR TITLE
Ensure Dusk uses log mailer

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -108,6 +108,20 @@ class AppServiceProvider extends ServiceProvider
                 if (!empty($mailSettings['from_name'])) {
                     config(['mail.from.name' => $mailSettings['from_name']]);
                 }
+
+                if (array_key_exists('disable_delivery', $mailSettings) && $mailSettings['disable_delivery'] !== null) {
+                    $disableDelivery = $mailSettings['disable_delivery'];
+
+                    if (! is_bool($disableDelivery)) {
+                        $disableDelivery = in_array(
+                            strtolower((string) $disableDelivery),
+                            ['1', 'true', 'yes', 'on'],
+                            true
+                        );
+                    }
+
+                    config(['mail.disable_delivery' => (bool) $disableDelivery]);
+                }
             }
 
             $appleWalletSettings = Setting::forGroup('wallet.apple');

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -2,10 +2,12 @@
 
 namespace Tests;
 
+use App\Models\Setting;
 use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
 use Laravel\Dusk\TestCase as BaseTestCase;
 use PHPUnit\Framework\Attributes\BeforeClass;
 
@@ -24,6 +26,13 @@ abstract class DuskTestCase extends BaseTestCase
             'mail.mailers.smtp.channel',
             $this->app['config']->get('mail.mailers.log.channel')
         );
+
+        if (Schema::hasTable('settings')) {
+            Setting::setGroup('mail', [
+                'mailer' => 'log',
+                'disable_delivery' => true,
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- respect the `disable_delivery` mail setting when bootstrapping the application so config toggles apply
- seed the mail settings during Dusk test setup so browser tests run with the log mailer and delivery disabled

## Testing
- composer install *(fails: requires GitHub token for downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68d1e0435178832eaf0cab1e4e58f3db