### PR TITLE
Bump version to 2.0.0b

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,6 @@ jobs:
           draft: false
           prerelease: false
           title: "Latest Release"
-          automatic_release_tag: "v1.0.32-dfiore1230"
+          automatic_release_tag: "2.0.0b"
           files: |
             eventschedule.zip

--- a/config/self-update.php
+++ b/config/self-update.php
@@ -28,7 +28,7 @@ return [
     |
     */
 
-    'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', 'v1.0.33-dfiore1230'),
+    'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', '2.0.0b'),
 
     'github_defaults' => [
         'vendor' => $defaultGithubVendor,


### PR DESCRIPTION
## Summary
- update the GitHub release workflow to publish version 2.0.0b
- set the default installed version configuration to 2.0.0b

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d331085e10832eb4411ea961f920de