### PR TITLE
Ensure event edit uses descriptive slug

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -463,7 +463,7 @@ class EventController extends Controller
         $currencies = file_get_contents(base_path('storage/currencies.json'));
         $currencies = json_decode($currencies);
 
-        $eventUrlData = $event->getGuestUrlData($subdomain, false);
+        $eventUrlData = $event->getGuestUrlData($subdomain, false, true);
         $matchingEvent = $this->eventRepo->getEvent($eventUrlData['subdomain'], $eventUrlData['slug'], false);        
         $isUnique = ! $matchingEvent || $matchingEvent->id == $event->id ? true : false;
 

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -397,9 +397,9 @@ class Event extends Model
         return '';
     }
 
-    public function getGuestUrl($subdomain = false, $date = null, $useCustomDomain = null)
+    public function getGuestUrl($subdomain = false, $date = null, $useCustomDomain = null, bool $forceEventSlug = false)
     {
-        $data = $this->getGuestUrlData($subdomain, $date);
+        $data = $this->getGuestUrlData($subdomain, $date, $forceEventSlug);
 
         if (! $data['subdomain']) {
             \Log::error('No subdomain found for event ' . $this->id);
@@ -427,7 +427,7 @@ class Event extends Model
         return url($relativeUrl);
     }
 
-    public function getGuestUrlData($subdomain = false, $date = null)
+    public function getGuestUrlData($subdomain = false, $date = null, bool $forceEventSlug = false)
     {
         $venueSubdomain = $this->venue && $this->venue->isClaimed() ? $this->venue->subdomain : null;
         $roleSubdomain = $this->role() && $this->role()->isClaimed() ? $this->role()->subdomain : null;
@@ -442,7 +442,11 @@ class Event extends Model
 
         $slug = $this->slug;
 
-        if ($venueSubdomain && $roleSubdomain) {
+        if (! $forceEventSlug && $venueSubdomain && $roleSubdomain) {
+            $slug = $venueSubdomain == $subdomain ? $roleSubdomain : $venueSubdomain;
+        }
+
+        if ($forceEventSlug && (! $slug) && $venueSubdomain && $roleSubdomain) {
             $slug = $venueSubdomain == $subdomain ? $roleSubdomain : $venueSubdomain;
         }
         

--- a/resources/views/event/edit.blade.php
+++ b/resources/views/event/edit.blade.php
@@ -151,7 +151,7 @@
     }
 
     function copyEventUrl(button) {
-        const url = '{{ $event->exists ? $event->getGuestUrl($subdomain, $isUnique ? null : true) : "" }}';
+        const url = '{{ $event->exists ? $event->getGuestUrl($subdomain, $isUnique ? null : true, null, true) : "" }}';
         navigator.clipboard.writeText(url).then(() => {
             const originalHTML = button.innerHTML;
             button.innerHTML = `
@@ -594,8 +594,8 @@
                             <x-input-error class="mt-2" :messages="$errors->get('name')" />
                             @if ($event->exists)
                             <div class="text-sm text-gray-500 flex items-center gap-2">
-                                <a href="{{ $event->getGuestUrl($subdomain, $isUnique ? null : true) }}" target="_blank" class="hover:underline">
-                                    {{ \App\Utils\UrlUtils::clean($event->getGuestUrl($subdomain, $isUnique ? null : true)) }}
+                                <a href="{{ $event->getGuestUrl($subdomain, $isUnique ? null : true, null, true) }}" target="_blank" class="hover:underline">
+                                    {{ \App\Utils\UrlUtils::clean($event->getGuestUrl($subdomain, $isUnique ? null : true, null, true)) }}
                                 </a>
                                 <button type="button" onclick="copyEventUrl(this)" class="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300" title="{{ __('messages.copy_url') }}">
                                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">


### PR DESCRIPTION
## Summary
- add an option to force use of the event's descriptive slug when generating guest URLs
- use the forced descriptive slug on the event edit page so the preview and copy link match the editable slug
- base the edit page uniqueness check on the descriptive slug as well

## Testing
- php -l app/Models/Event.php
- php -l app/Http/Controllers/EventController.php

------
https://chatgpt.com/codex/tasks/task_e_68d35391119c832ea2e7cc163959268a