### PR TITLE
Guard navigation contact link when route absent

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -4,6 +4,9 @@
     $curators = isset($curators) ? $curators : collect();
 
     $scheduleRoutes = ['role.pages', 'role.venues', 'role.curators', 'role.talent', 'role.contacts', 'role.view_admin'];
+    $scheduleRoutes = array_values(array_filter($scheduleRoutes, function ($routeName) {
+        return \Illuminate\Support\Facades\Route::has($routeName);
+    }));
     $schedulesActive = false;
     foreach ($scheduleRoutes as $routeName) {
         if (request()->routeIs($routeName)) {
@@ -202,16 +205,18 @@
                                 </ul>
                             @endif
                         </li>
-                        <li>
-                            <a href="{{ route('role.contacts') }}"
-                                class="group flex gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->routeIs('role.contacts') ? 'bg-gray-800 text-white' : '' }}">
-                                <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="{{ request()->routeIs('role.contacts') ? '#ccc' : '#666' }}" stroke-width="1.5" aria-hidden="true">
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 5.25h15a.75.75 0 01.75.75v12.75a.75.75 0 01-.75.75h-15a.75.75 0 01-.75-.75V6a.75.75 0 01.75-.75z" />
-                                    <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 8.25h7.5M8.25 12h4.5M8.25 15.75H12" />
-                                </svg>
-                                {{ __('messages.contacts') }}
-                            </a>
-                        </li>
+                        @if (\Illuminate\Support\Facades\Route::has('role.contacts'))
+                            <li>
+                                <a href="{{ route('role.contacts') }}"
+                                    class="group flex gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->routeIs('role.contacts') ? 'bg-gray-800 text-white' : '' }}">
+                                    <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="{{ request()->routeIs('role.contacts') ? '#ccc' : '#666' }}" stroke-width="1.5" aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 5.25h15a.75.75 0 01.75.75v12.75a.75.75 0 01-.75.75h-15a.75.75 0 01-.75-.75V6a.75.75 0 01.75-.75z" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 8.25h7.5M8.25 12h4.5M8.25 15.75H12" />
+                                    </svg>
+                                    {{ __('messages.contacts') }}
+                                </a>
+                            </li>
+                        @endif
                     </ul>
                 </li>
 


### PR DESCRIPTION
## Summary
- filter the schedules navigation route list to only include registered routes
- only render the contacts navigation link when the role.contacts route exists to prevent RouteNotFoundException errors

## Testing
- composer install --no-interaction *(fails: GitHub API 403 when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d358e5802c832e8d7afcb88e9dfb8c