### PR TITLE
Bump release version to 2.0.1b

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,6 @@ jobs:
           draft: false
           prerelease: false
           title: "Latest Release"
-          automatic_release_tag: "2.0.0b"
+          automatic_release_tag: "2.0.1b"
           files: |
             eventschedule.zip

--- a/config/self-update.php
+++ b/config/self-update.php
@@ -28,7 +28,7 @@ return [
     |
     */
 
-    'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', '2.0.0b'),
+    'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', '2.0.1b'),
 
     'github_defaults' => [
         'vendor' => $defaultGithubVendor,


### PR DESCRIPTION
## Summary
- update the packaged release tag in the build workflow to 2.0.1b
- set the default installed version in the self-update configuration to 2.0.1b

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d366078908832e9b7aa04505926dfb