### PR TITLE
Restore admin event overview link

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -226,7 +226,10 @@
                                                         );
                                                     @endphp
 
-                                                    @if ($eventGuestUrl)
+                                                    @if ($canEdit)
+                                                        <a href="{{ route('events.view', ['hash' => $hashedId]) }}" target="_blank" rel="noopener noreferrer"
+                                                           class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">{{ __('messages.view_event') }}</a>
+                                                    @elseif ($eventGuestUrl)
                                                         <a href="{{ $eventGuestUrl }}" target="_blank" rel="noopener noreferrer"
                                                            class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">{{ __('messages.view_event') }}</a>
                                                     @endif


### PR DESCRIPTION
## Summary
- update the events list view to open the admin event overview when the user can edit the event
- fall back to the public event page link for users without edit permissions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d368bb7b6c832e9b1fe928197fccc7