### PR TITLE
Fix Add Event button to open modal

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -128,7 +128,7 @@
                         <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{{ __('messages.events') }}</h2>
                     </div>
                     @if ($creationRoles->isNotEmpty())
-                        <x-primary-button type="button" @click="$dispatch('open-modal', 'create-event')">
+                        <x-primary-button type="button" x-data="" @click="$dispatch('open-modal', 'create-event')">
                             {{ __('messages.add_event') }}
                         </x-primary-button>
                     @endif


### PR DESCRIPTION
## Summary
- ensure the Events page "Add Event" trigger is an Alpine component so the modal can open

## Testing
- not run (missing PHP vendor dependencies in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d36b686ac0832e969e0e77382fbf46