### PR TITLE
Restore Add Event button on events calendar

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -265,7 +265,12 @@
             </div>
         </div>
 
-        @include('role/partials/calendar', ['route' => 'home', 'tab' => '', 'events' => $calendarEvents])
+        @include('role/partials/calendar', [
+            'route' => 'home',
+            'tab' => '',
+            'events' => $calendarEvents,
+            'canCreateEvent' => $creationRoles->isNotEmpty(),
+        ])
 
         @if ($creationRoles->isNotEmpty())
             <x-modal name="create-event">

--- a/resources/views/role/partials/calendar.blade.php
+++ b/resources/views/role/partials/calendar.blade.php
@@ -202,6 +202,14 @@
                         {{ __('messages.add_event') }}
                     </button>
                 </a>
+            @elseif ($route == 'home' && ($canCreateEvent ?? false))
+                <button type="button" x-data="" @click="$dispatch('open-modal', 'create-event')"
+                    class="w-full md:w-auto inline-flex items-center justify-center rounded-md shadow-sm bg-[#4E81FA] px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-[#3A6BE0] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4E81FA]">
+                    <svg class="{{ isset($role) && $role->isRtl() && ! session()->has('translate') ? '-mr-0.5 ml-1.5' : '-ml-0.5 mr-1.5' }} h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" />
+                    </svg>
+                    {{ __('messages.add_event') }}
+                </button>
             @endif
         </div>
     </div>


### PR DESCRIPTION
## Summary
- pass a flag from the events dashboard so the calendar header knows when the user can create events
- render the Add Event control in the calendar header for the home route and trigger the existing creation modal

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f4c46c64832e9d1a69623fa2e5b4