### PR TITLE
Promote key sections to top-level admin navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@
 - 🔍 **Search Feature:** Powerful search functionality to help users find specific events or content across your schedule.
 - 🎨 **Event Graphics Generator:** Create beautiful graphics of your upcoming events with flyers, QR codes, and event details for social media and marketing.
 - 🔌 **REST API:** Access and manage your events programmatically through a REST API.
-- 🚀 **Automatic App Updates:** Keep the platform up to date effortlessly with one-click automatic updates.  
+- 🚀 **Automatic App Updates:** Keep the platform up to date effortlessly with one-click automatic updates.
+- 🧭 **Streamlined Admin Navigation:** Reach Venues, Talent, and Curators from top-level menus while keeping their detailed sub-navigation intact.
 
 <div style="display: flex; gap: 10px;">
     <img src="https://github.com/eventschedule/eventschedule/blob/main/public/images/screenshots/screen_1.png?raw=true" width="49%" alt="Guest > Schedule">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -3,7 +3,7 @@
     $venues = isset($venues) ? $venues : collect();
     $curators = isset($curators) ? $curators : collect();
 
-    $scheduleRoutes = ['role.pages', 'role.venues', 'role.curators', 'role.talent', 'role.contacts', 'role.view_admin'];
+    $scheduleRoutes = ['role.pages'];
     $scheduleRoutes = array_values(array_filter($scheduleRoutes, function ($routeName) {
         return \Illuminate\Support\Facades\Route::has($routeName);
     }));
@@ -71,154 +71,153 @@
                         </svg>
                         {{ __('messages.schedules') }}
                     </a>
-
-                    <ul role="list" class="mt-1 space-y-1 pl-9">
-                        <li data-collapse-container class="space-y-1" data-collapse-state="{{ $venuesSectionOpen ? 'open' : 'closed' }}">
-                            <div class="flex items-center gap-x-2">
-                                <a href="{{ route('role.venues') }}"
-                                    class="group flex flex-1 gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ $venuesSectionOpen ? 'bg-gray-800 text-white' : '' }}">
-                                    <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="none"
-                                        stroke="{{ $venuesSectionOpen ? '#ccc' : '#666' }}" stroke-width="1.5" aria-hidden="true">
-                                        <path stroke-linecap="round" stroke-linejoin="round"
-                                            d="M3 21h18M4.5 21V9l7.5-4.5L19.5 9V21M9 21v-6h6v6" />
-                                    </svg>
-                                    <span class="flex-1 text-left">{{ __('messages.venues') }}</span>
-                                </a>
-
-                                @if ($venues->isNotEmpty())
-                                    <button type="button"
-                                        class="ml-1 inline-flex items-center rounded-md p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                                        data-collapse-trigger aria-controls="collapse-venues"
-                                        aria-expanded="{{ $venuesSectionOpen ? 'true' : 'false' }}">
-                                        <span class="sr-only">{{ __('Toggle :menu menu', ['menu' => __('messages.venues')]) }}</span>
-                                        <svg data-collapse-icon class="h-4 w-4 transform transition-transform duration-200" viewBox="0 0 20 20" fill="none"
-                                            stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4" />
-                                        </svg>
-                                    </button>
-                                @endif
-                            </div>
-
-                            @if ($venues->isNotEmpty())
-                                <ul role="list" id="collapse-venues" data-collapse-content
-                                    class="mt-1 space-y-1 pl-9 {{ $venuesSectionOpen ? '' : 'hidden' }}">
-                                    <li class="px-2 text-xs font-semibold leading-6 text-gray-400">{{ __('messages.venue_schedules') }}</li>
-
-                                    @foreach ($venues as $venue)
-                                        <li>
-                                            <a href="{{ route('role.view_admin', ['subdomain' => $venue->subdomain, 'tab' => $venue->subdomain == request()->subdomain ? 'schedule' : (request()->tab ? request()->tab : 'schedule')]) }}"
-                                                class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 hover:bg-gray-800 hover:text-white {{ request()->is($venue->subdomain) || request()->is($venue->subdomain . '/*') ? 'bg-gray-800 text-white' : 'text-gray-400' }}">
-                                                <span
-                                                    class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-[0.625rem] font-medium group-hover:text-white {{ request()->is($venue->subdomain) || request()->is($venue->subdomain . '/*') ? 'text-white' : 'text-gray-400' }}">{{ strtoupper(substr($venue->name, 0, 1)) }}</span>
-                                                <span class="truncate">{{ $venue->name }}</span>
-                                            </a>
-                                        </li>
-                                    @endforeach
-                                </ul>
-                            @endif
-                        </li>
-
-                        <li data-collapse-container class="space-y-1" data-collapse-state="{{ $curatorsSectionOpen ? 'open' : 'closed' }}">
-                            <div class="flex items-center gap-x-2">
-                                <a href="{{ route('role.curators') }}"
-                                    class="group flex flex-1 gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ $curatorsSectionOpen ? 'bg-gray-800 text-white' : '' }}">
-                                    <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24"
-                                        fill="{{ $curatorsSectionOpen ? '#ccc' : '#666' }}" aria-hidden="true">
-                                        <path d="M12 4l2.47 5.02 5.53.8-4 3.91.94 5.5L12 16.9l-4.94 2.33.94-5.5-4-3.91 5.53-.8L12 4z" />
-                                    </svg>
-                                    <span class="flex-1 text-left">{{ __('messages.curators') }}</span>
-                                </a>
-
-                                @if ($curators->isNotEmpty())
-                                    <button type="button"
-                                        class="ml-1 inline-flex items-center rounded-md p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                                        data-collapse-trigger aria-controls="collapse-curators"
-                                        aria-expanded="{{ $curatorsSectionOpen ? 'true' : 'false' }}">
-                                        <span class="sr-only">{{ __('Toggle :menu menu', ['menu' => __('messages.curators')]) }}</span>
-                                        <svg data-collapse-icon class="h-4 w-4 transform transition-transform duration-200" viewBox="0 0 20 20" fill="none"
-                                            stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4" />
-                                        </svg>
-                                    </button>
-                                @endif
-                            </div>
-
-                            @if ($curators->isNotEmpty())
-                                <ul role="list" id="collapse-curators" data-collapse-content
-                                    class="mt-1 space-y-1 pl-9 {{ $curatorsSectionOpen ? '' : 'hidden' }}">
-                                    <li class="px-2 text-xs font-semibold leading-6 text-gray-400">{{ __('messages.curator_schedules') }}</li>
-
-                                    @foreach ($curators as $curator)
-                                        <li>
-                                            <a href="{{ route('role.view_admin', ['subdomain' => $curator->subdomain, 'tab' => $curator->subdomain == request()->subdomain ? 'schedule' : (request()->tab ? request()->tab : 'schedule')]) }}"
-                                                class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 hover:bg-gray-800 hover:text-white {{ request()->is($curator->subdomain) || request()->is($curator->subdomain . '/*') ? 'bg-gray-800 text-white' : 'text-gray-400' }}">
-                                                <span
-                                                    class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-[0.625rem] font-medium group-hover:text-white {{ request()->is($curator->subdomain) || request()->is($curator->subdomain . '/*') ? 'text-white' : 'text-gray-400' }}">{{ strtoupper(substr($curator->name, 0, 1)) }}</span>
-                                                <span class="truncate">{{ $curator->name }}</span>
-                                            </a>
-                                        </li>
-                                    @endforeach
-                                </ul>
-                            @endif
-                        </li>
-
-                        <li data-collapse-container class="space-y-1" data-collapse-state="{{ $talentSectionOpen ? 'open' : 'closed' }}">
-                            <div class="flex items-center gap-x-2">
-                                <a href="{{ route('role.talent') }}"
-                                    class="group flex flex-1 gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ $talentSectionOpen ? 'bg-gray-800 text-white' : '' }}">
-                                    <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24"
-                                        fill="{{ $talentSectionOpen ? '#ccc' : '#666' }}" aria-hidden="true">
-                                        <path d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8zm0 2c-3.33 0-6 2.24-6 5v1h12v-1c0-2.76-2.67-5-6-5z" />
-                                    </svg>
-                                    <span class="flex-1 text-left">{{ \Illuminate\Support\Str::plural(__('messages.talent')) }}</span>
-                                </a>
-
-                                @if ($schedules->isNotEmpty())
-                                    <button type="button"
-                                        class="ml-1 inline-flex items-center rounded-md p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                                        data-collapse-trigger aria-controls="collapse-talent"
-                                        aria-expanded="{{ $talentSectionOpen ? 'true' : 'false' }}">
-                                        <span class="sr-only">{{ __('Toggle :menu menu', ['menu' => \Illuminate\Support\Str::plural(__('messages.talent'))]) }}</span>
-                                        <svg data-collapse-icon class="h-4 w-4 transform transition-transform duration-200" viewBox="0 0 20 20" fill="none"
-                                            stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4" />
-                                        </svg>
-                                    </button>
-                                @endif
-                            </div>
-
-                            @if ($schedules->isNotEmpty())
-                                <ul role="list" id="collapse-talent" data-collapse-content
-                                    class="mt-1 space-y-1 pl-9 {{ $talentSectionOpen ? '' : 'hidden' }}">
-                                    <li class="px-2 text-xs font-semibold leading-6 text-gray-400">{{ __('messages.talent_schedules') }}</li>
-
-                                    @foreach ($schedules as $each)
-                                        <li>
-                                            <a href="{{ route('role.view_admin', ['subdomain' => $each->subdomain, 'tab' => $each->subdomain == request()->subdomain ? 'schedule' : (request()->tab ? request()->tab : 'schedule')]) }}"
-                                                class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 hover:bg-gray-800 hover:text-white {{ request()->is($each->subdomain) || request()->is($each->subdomain . '/*') ? 'bg-gray-800 text-white' : 'text-gray-400' }}">
-                                                <span
-                                                    class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-[0.625rem] font-medium group-hover:text-white {{ request()->is($each->subdomain) || request()->is($each->subdomain . '/*') ? 'text-white' : 'text-gray-400' }}">{{ strtoupper(substr($each->name, 0, 1)) }}</span>
-                                                <span class="truncate">{{ $each->name }}</span>
-                                            </a>
-                                        </li>
-                                    @endforeach
-                                </ul>
-                            @endif
-                        </li>
-                        @if (\Illuminate\Support\Facades\Route::has('role.contacts'))
-                            <li>
-                                <a href="{{ route('role.contacts') }}"
-                                    class="group flex gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->routeIs('role.contacts') ? 'bg-gray-800 text-white' : '' }}">
-                                    <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="{{ request()->routeIs('role.contacts') ? '#ccc' : '#666' }}" stroke-width="1.5" aria-hidden="true">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 5.25h15a.75.75 0 01.75.75v12.75a.75.75 0 01-.75.75h-15a.75.75 0 01-.75-.75V6a.75.75 0 01.75-.75z" />
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 8.25h7.5M8.25 12h4.5M8.25 15.75H12" />
-                                    </svg>
-                                    {{ __('messages.contacts') }}
-                                </a>
-                            </li>
-                        @endif
-                    </ul>
                 </li>
+
+                <li data-collapse-container class="space-y-1" data-collapse-state="{{ $venuesSectionOpen ? 'open' : 'closed' }}">
+                    <div class="flex items-center gap-x-2">
+                        <a href="{{ route('role.venues') }}"
+                            class="group flex flex-1 gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ $venuesSectionOpen ? 'bg-gray-800 text-white' : '' }}">
+                            <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="none"
+                                stroke="{{ $venuesSectionOpen ? '#ccc' : '#666' }}" stroke-width="1.5" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round"
+                                    d="M3 21h18M4.5 21V9l7.5-4.5L19.5 9V21M9 21v-6h6v6" />
+                            </svg>
+                            <span class="flex-1 text-left">{{ __('messages.venues') }}</span>
+                        </a>
+
+                        @if ($venues->isNotEmpty())
+                            <button type="button"
+                                class="ml-1 inline-flex items-center rounded-md p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                data-collapse-trigger aria-controls="collapse-venues"
+                                aria-expanded="{{ $venuesSectionOpen ? 'true' : 'false' }}">
+                                <span class="sr-only">{{ __('Toggle :menu menu', ['menu' => __('messages.venues')]) }}</span>
+                                <svg data-collapse-icon class="h-4 w-4 transform transition-transform duration-200" viewBox="0 0 20 20" fill="none"
+                                    stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4" />
+                                </svg>
+                            </button>
+                        @endif
+                    </div>
+
+                    @if ($venues->isNotEmpty())
+                        <ul role="list" id="collapse-venues" data-collapse-content
+                            class="mt-1 space-y-1 pl-9 {{ $venuesSectionOpen ? '' : 'hidden' }}">
+                            <li class="px-2 text-xs font-semibold leading-6 text-gray-400">{{ __('messages.venue_schedules') }}</li>
+
+                            @foreach ($venues as $venue)
+                                <li>
+                                    <a href="{{ route('role.view_admin', ['subdomain' => $venue->subdomain, 'tab' => $venue->subdomain == request()->subdomain ? 'schedule' : (request()->tab ? request()->tab : 'schedule')]) }}"
+                                        class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 hover:bg-gray-800 hover:text-white {{ request()->is($venue->subdomain) || request()->is($venue->subdomain . '/*') ? 'bg-gray-800 text-white' : 'text-gray-400' }}">
+                                        <span
+                                            class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-[0.625rem] font-medium group-hover:text-white {{ request()->is($venue->subdomain) || request()->is($venue->subdomain . '/*') ? 'text-white' : 'text-gray-400' }}">{{ strtoupper(substr($venue->name, 0, 1)) }}</span>
+                                        <span class="truncate">{{ $venue->name }}</span>
+                                    </a>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </li>
+
+                <li data-collapse-container class="space-y-1" data-collapse-state="{{ $curatorsSectionOpen ? 'open' : 'closed' }}">
+                    <div class="flex items-center gap-x-2">
+                        <a href="{{ route('role.curators') }}"
+                            class="group flex flex-1 gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ $curatorsSectionOpen ? 'bg-gray-800 text-white' : '' }}">
+                            <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24"
+                                fill="{{ $curatorsSectionOpen ? '#ccc' : '#666' }}" aria-hidden="true">
+                                <path d="M12 4l2.47 5.02 5.53.8-4 3.91.94 5.5L12 16.9l-4.94 2.33.94-5.5-4-3.91 5.53-.8L12 4z" />
+                            </svg>
+                            <span class="flex-1 text-left">{{ __('messages.curators') }}</span>
+                        </a>
+
+                        @if ($curators->isNotEmpty())
+                            <button type="button"
+                                class="ml-1 inline-flex items-center rounded-md p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                data-collapse-trigger aria-controls="collapse-curators"
+                                aria-expanded="{{ $curatorsSectionOpen ? 'true' : 'false' }}">
+                                <span class="sr-only">{{ __('Toggle :menu menu', ['menu' => __('messages.curators')]) }}</span>
+                                <svg data-collapse-icon class="h-4 w-4 transform transition-transform duration-200" viewBox="0 0 20 20" fill="none"
+                                    stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4" />
+                                </svg>
+                            </button>
+                        @endif
+                    </div>
+
+                    @if ($curators->isNotEmpty())
+                        <ul role="list" id="collapse-curators" data-collapse-content
+                            class="mt-1 space-y-1 pl-9 {{ $curatorsSectionOpen ? '' : 'hidden' }}">
+                            <li class="px-2 text-xs font-semibold leading-6 text-gray-400">{{ __('messages.curator_schedules') }}</li>
+
+                            @foreach ($curators as $curator)
+                                <li>
+                                    <a href="{{ route('role.view_admin', ['subdomain' => $curator->subdomain, 'tab' => $curator->subdomain == request()->subdomain ? 'schedule' : (request()->tab ? request()->tab : 'schedule')]) }}"
+                                        class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 hover:bg-gray-800 hover:text-white {{ request()->is($curator->subdomain) || request()->is($curator->subdomain . '/*') ? 'bg-gray-800 text-white' : 'text-gray-400' }}">
+                                        <span
+                                            class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-[0.625rem] font-medium group-hover:text-white {{ request()->is($curator->subdomain) || request()->is($curator->subdomain . '/*') ? 'text-white' : 'text-gray-400' }}">{{ strtoupper(substr($curator->name, 0, 1)) }}</span>
+                                        <span class="truncate">{{ $curator->name }}</span>
+                                    </a>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </li>
+
+                <li data-collapse-container class="space-y-1" data-collapse-state="{{ $talentSectionOpen ? 'open' : 'closed' }}">
+                    <div class="flex items-center gap-x-2">
+                        <a href="{{ route('role.talent') }}"
+                            class="group flex flex-1 gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ $talentSectionOpen ? 'bg-gray-800 text-white' : '' }}">
+                            <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24"
+                                fill="{{ $talentSectionOpen ? '#ccc' : '#666' }}" aria-hidden="true">
+                                <path d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8zm0 2c-3.33 0-6 2.24-6 5v1h12v-1c0-2.76-2.67-5-6-5z" />
+                            </svg>
+                            <span class="flex-1 text-left">{{ \Illuminate\Support\Str::plural(__('messages.talent')) }}</span>
+                        </a>
+
+                        @if ($schedules->isNotEmpty())
+                            <button type="button"
+                                class="ml-1 inline-flex items-center rounded-md p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                data-collapse-trigger aria-controls="collapse-talent"
+                                aria-expanded="{{ $talentSectionOpen ? 'true' : 'false' }}">
+                                <span class="sr-only">{{ __('Toggle :menu menu', ['menu' => \Illuminate\Support\Str::plural(__('messages.talent'))]) }}</span>
+                                <svg data-collapse-icon class="h-4 w-4 transform transition-transform duration-200" viewBox="0 0 20 20" fill="none"
+                                    stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 8l4 4 4-4" />
+                                </svg>
+                            </button>
+                        @endif
+                    </div>
+
+                    @if ($schedules->isNotEmpty())
+                        <ul role="list" id="collapse-talent" data-collapse-content
+                            class="mt-1 space-y-1 pl-9 {{ $talentSectionOpen ? '' : 'hidden' }}">
+                            <li class="px-2 text-xs font-semibold leading-6 text-gray-400">{{ __('messages.talent_schedules') }}</li>
+
+                            @foreach ($schedules as $each)
+                                <li>
+                                    <a href="{{ route('role.view_admin', ['subdomain' => $each->subdomain, 'tab' => $each->subdomain == request()->subdomain ? 'schedule' : (request()->tab ? request()->tab : 'schedule')]) }}"
+                                        class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 hover:bg-gray-800 hover:text-white {{ request()->is($each->subdomain) || request()->is($each->subdomain . '/*') ? 'bg-gray-800 text-white' : 'text-gray-400' }}">
+                                        <span
+                                            class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-[0.625rem] font-medium group-hover:text-white {{ request()->is($each->subdomain) || request()->is($each->subdomain . '/*') ? 'text-white' : 'text-gray-400' }}">{{ strtoupper(substr($each->name, 0, 1)) }}</span>
+                                        <span class="truncate">{{ $each->name }}</span>
+                                    </a>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </li>
+
+                @if (\Illuminate\Support\Facades\Route::has('role.contacts'))
+                    <li>
+                        <a href="{{ route('role.contacts') }}"
+                            class="group flex gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->routeIs('role.contacts') ? 'bg-gray-800 text-white' : '' }}">
+                            <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="{{ request()->routeIs('role.contacts') ? '#ccc' : '#666' }}" stroke-width="1.5" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 5.25h15a.75.75 0 01.75.75v12.75a.75.75 0 01-.75.75h-15a.75.75 0 01-.75-.75V6a.75.75 0 01.75-.75z" />
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 8.25h7.5M8.25 12h4.5M8.25 15.75H12" />
+                            </svg>
+                            {{ __('messages.contacts') }}
+                        </a>
+                    </li>
+                @endif
 
                 @if (config('app.hosted'))
                 <li>


### PR DESCRIPTION
## Summary
- expose Venues, Curators, and Talent as first-level entries in the admin navigation while preserving their collapsible submenus
- narrow the schedule highlighting logic so only the schedules landing page marks the item active
- note the streamlined admin navigation in the README feature list

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php because Composer dependencies are not installed; installing dependencies requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f7b77310832eac55a8d2a49ddea8