### PR TITLE
Add breadcrumbs to role management pages

### DIFF
--- a/resources/views/components/breadcrumbs.blade.php
+++ b/resources/views/components/breadcrumbs.blade.php
@@ -1,0 +1,53 @@
+@props([
+    'items' => [],
+    'ariaLabel' => __('Breadcrumb'),
+])
+
+@php
+    $items = collect($items)
+        ->map(function ($item) {
+            return is_array($item) ? $item : [];
+        })
+        ->filter(function ($item) {
+            return filled($item['label'] ?? null);
+        })
+        ->values();
+@endphp
+
+@if ($items->isNotEmpty())
+    <nav aria-label="{{ $ariaLabel }}" {{ $attributes->merge(['class' => 'flex text-sm text-gray-500 dark:text-gray-400']) }}>
+        <ol role="list" class="flex flex-wrap items-center gap-x-2 gap-y-1">
+            @foreach ($items as $index => $item)
+                <li class="flex items-center gap-2">
+                    @if ($index > 0)
+                        <svg class="h-4 w-4 text-gray-400 dark:text-gray-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                            <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L9.586 11 7.293 8.707a1 1 0 111.414-1.414l3 3a1 1 0 010 1.414l-3 3a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                        </svg>
+                    @endif
+
+                    @php
+                        $isCurrent = (bool) ($item['current'] ?? false);
+                        $label = $item['label'];
+                        $url = $item['url'] ?? null;
+                    @endphp
+
+                    @if ($url && ! $isCurrent)
+                        <a
+                            href="{{ $url }}"
+                            class="truncate font-medium text-gray-500 transition hover:text-gray-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4E81FA] dark:text-gray-400 dark:hover:text-gray-200"
+                        >
+                            {{ $label }}
+                        </a>
+                    @else
+                        <span
+                            class="truncate font-medium text-gray-700 dark:text-gray-200"
+                            @if ($isCurrent) aria-current="page" @endif
+                        >
+                            {{ $label }}
+                        </span>
+                    @endif
+                </li>
+            @endforeach
+        </ol>
+    </nav>
+@endif

--- a/resources/views/components/role-breadcrumbs.blade.php
+++ b/resources/views/components/role-breadcrumbs.blade.php
@@ -1,0 +1,46 @@
+@props([
+    'role' => null,
+    'type' => null,
+    'current' => null,
+])
+
+@php
+    $roleType = $type ?? ($role?->type);
+    $currentLabel = $current ?? ($role?->name);
+
+    $listConfig = [
+        'venue' => [
+            'route' => 'role.venues',
+            'label' => __('messages.venues'),
+        ],
+        'curator' => [
+            'route' => 'role.curators',
+            'label' => __('messages.curators'),
+        ],
+        'talent' => [
+            'route' => 'role.talent',
+            'label' => \Illuminate\Support\Str::plural(__('messages.talent')),
+        ],
+    ];
+
+    $items = collect();
+
+    if ($roleType && array_key_exists($roleType, $listConfig)) {
+        $config = $listConfig[$roleType];
+        $items->push([
+            'label' => $config['label'],
+            'url' => route($config['route']),
+        ]);
+
+        if (filled($currentLabel)) {
+            $items->push([
+                'label' => $currentLabel,
+                'current' => true,
+            ]);
+        }
+    }
+@endphp
+
+@if ($items->count() > 1)
+    <x-breadcrumbs :items="$items->all()" {{ $attributes }} />
+@endif

--- a/resources/views/role/edit.blade.php
+++ b/resources/views/role/edit.blade.php
@@ -448,6 +448,12 @@
 
     </x-slot>
 
+    <x-role-breadcrumbs
+        :role="$role"
+        :current="$role->exists ? $role->name : $title"
+        class="mb-4"
+    />
+
     <h2 class="pt-2 my-4 text-xl font-bold leading-7 text-gray-900 dark:text-gray-100x sm:truncate sm:text-2xl sm:tracking-tight">
         {{ $title }}
     </h2>

--- a/resources/views/role/show-admin.blade.php
+++ b/resources/views/role/show-admin.blade.php
@@ -82,45 +82,9 @@
 
     </form>
 
-    <div class="pt-2">
-        <!--
-        <div>
-            <nav class="sm:hidden" aria-label="Back">
-                <a href="#" class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700">
-                    <svg class="-ml-1 mr-1 h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 24 24" fill="currentColor"
-                        aria-hidden="true">
-                        <path fill-rule="evenodd"
-                            d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z"
-                            clip-rule="evenodd" />
-                    </svg>
-                    {{ __('messages.back') }}
-                </a>
-            </nav>
-            <nav class="hidden sm:flex" aria-label="Breadcrumb">
-                <ol role="list" class="flex items-center space-x-4">
-                    <li>
-                        <div class="flex">
-                            <a href="#"
-                                class="mr-4 text-sm font-medium text-gray-500 hover:text-gray-700">{{ __('messages.' . strtolower($role->type)) }}</a>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="flex items-center">
-                            <svg class="h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 24 24" fill="currentColor"
-                                aria-hidden="true">
-                                <path fill-rule="evenodd"
-                                    d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
-                                    clip-rule="evenodd" />
-                            </svg>
-                            <a href="#" aria-current="page"
-                                class="mr-4 text-sm font-medium text-gray-500 hover:text-gray-700">{{ $role->name }}</a>
-                        </div>
-                    </li>
-                </ol>
-            </nav>
-        </div>
-        -->
-        <div class="mt-2 flex items-top justify-between">
+    <div class="pt-2 space-y-4">
+        <x-role-breadcrumbs :role="$role" class="text-sm" />
+        <div class="flex items-start justify-between">
             @if ($role->profile_image_url)
                 <div class="pr-4">
                     <img src="{{ $role->profile_image_url }}" class="rounded-lg h-14 w-14 flex-none">

--- a/tests/Feature/RoleListingTest.php
+++ b/tests/Feature/RoleListingTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class RoleListingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'app.hosted' => false,
+            'app.is_testing' => true,
+            'services.google.backend' => null,
+        ]);
+    }
+
+    /**
+     * @dataProvider roleListingProvider
+     */
+    public function test_role_listing_pages_show_owned_roles_only(string $routeName, string $type, ?string $titleKey, string $createKey): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $ownedRole = $this->createRoleForUser($user, $type, 'Owned ' . Str::title($type));
+        $this->createRoleForUser($otherUser, $type, 'Hidden ' . Str::title($type));
+
+        $this->actingAs($user);
+
+        $response = $this->get(route($routeName));
+
+        $response->assertOk();
+
+        $expectedTitle = $titleKey
+            ? __('messages.' . $titleKey)
+            : Str::plural(__('messages.talent'));
+
+        $response->assertSeeText($expectedTitle);
+        $response->assertSeeText(__('messages.' . $createKey));
+        $response->assertSeeText($ownedRole->name);
+        $response->assertSee(route('role.view_admin', ['subdomain' => $ownedRole->subdomain, 'tab' => 'schedule']), false);
+        $response->assertDontSeeText('Hidden ' . Str::title($type));
+    }
+
+    public static function roleListingProvider(): array
+    {
+        return [
+            'venues' => ['role.venues', 'venue', 'venues', 'new_venue'],
+            'curators' => ['role.curators', 'curator', 'curators', 'new_curator'],
+            'talent' => ['role.talent', 'talent', null, 'new_talent'],
+        ];
+    }
+
+    private function createRoleForUser(?User $user, string $type, string $name): Role
+    {
+        $role = new Role([
+            'type' => $type,
+            'name' => $name,
+            'email' => Str::slug($name) . '@example.com',
+        ]);
+
+        $role->subdomain = Role::generateSubdomain($name);
+
+        if ($user) {
+            $role->user_id = $user->id;
+        }
+
+        $role->save();
+
+        if ($user) {
+            $role->users()->attach($user->id, ['level' => 'owner']);
+        }
+
+        return $role;
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable breadcrumb component and role-specific wrapper
- display breadcrumbs on role admin and edit pages to link back to list views
- add feature coverage to ensure the venues, curators, and talent listings render the owned roles

## Testing
- php artisan test *(fails: vendor/autoload.php missing because Composer dependencies cannot be installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f9b54aac832e9e75f17c3bb578d3